### PR TITLE
AppStore Search, AppSettings, DevTools

### DIFF
--- a/rockwork/qml/pages/AppSettingsPage.qml
+++ b/rockwork/qml/pages/AppSettingsPage.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.2
 import Sailfish.Silica 1.0
 import QtWebKit 3.0
+//import QtWebKit.experimental 1.0
 
 Page {
     id: settings
@@ -8,16 +9,21 @@ Page {
     property string uuid;
     property string url;
     property var pebble;
-
-
     SilicaWebView {
         id: webview
         anchors.fill: parent
 
         url: settings.url
-        header: PageHeader {
-            title: qsTr("App Settings")
+        /*header: Label {
+            text: qsTr("App Settings")
+            width: parent.width
+            horizontalAlignment: Text.AlignRight
+            color: Theme.highlightColor
+        }*/
+        VerticalScrollDecorator {
+            flickable: parent
         }
+
         onNavigationRequested: {
             //The pebblejs:// protocol is handeled by the urihandler, as it appears we can't intercept it
             var url = request.url.toString();
@@ -28,5 +34,44 @@ Page {
                 pageStack.pop();
             }
         }
+        experimental.preferences.webGLEnabled: true
+        //experimental.preferences.webAudioEnabled: true
+        //experimental.preferredMinimumContentsWidth: 980
+        experimental.itemSelector: Component {
+            id: selBox
+            Rectangle {
+                property QtObject selectorModel: model
+                anchors.fill: webview
+                color: Theme.rgba(Theme.highlightDimmerColor, 0.75)
+                Button {
+                    text: qsTr("Cancel")
+                    onClicked: selectorModel.reject()
+                    anchors.horizontalCenter: parent.horizontalCenter
+                }
+
+                SilicaListView {
+                    width: parent.width
+                    height: parent.height-Theme.itemSizeSmall
+                    anchors.bottom: parent.bottom
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    model: selectorModel.items
+                    delegate: ListItem {
+                        enabled: model.enabled
+                        contentHeight: Theme.itemSizeSmall
+                        Label {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: model.text
+                            color: model.enabled ? Theme.primaryColor : Theme.secondaryHighlightColor
+                        }
+                        onClicked: selectorModel.accept(index);
+                    }
+                }
+            }
+        }
+
+        //experimental.alertDialog: AlertDialog { }
+        //experimental.confirmDialog: ConfirmDialog { }
+        //experimental.promptDialog: PromptDialog { }
+
     }
 }

--- a/rockwork/qml/pages/AppStorePage.qml
+++ b/rockwork/qml/pages/AppStorePage.qml
@@ -195,7 +195,7 @@ Page {
             height: parent.height
             width: height
             icon.source: "image://theme/icon-m-search"
-            onClicked: client.search(searchTextField.displayText, root.showWatchApps ? AppStoreClient.TypeWatchapp : AppStoreClient.TypeWatchface);
+            onClicked: client.search(searchTextField.text, root.showWatchApps ? AppStoreClient.TypeWatchapp : AppStoreClient.TypeWatchface);
         }
     }
 }

--- a/rockwork/qml/pages/DeveloperToolsPage.qml
+++ b/rockwork/qml/pages/DeveloperToolsPage.qml
@@ -1,14 +1,45 @@
-import QtQuick 2.4
-import QtQuick.Layouts 1.1
-import Ubuntu.Components 1.3
-import Ubuntu.Components.Popups 1.3
-import Ubuntu.Content 1.3
+import QtQuick 2.2
+import Sailfish.Silica 1.0
 
 Page {
     id: root
-    title: i18n.tr("Developer Tools")
 
     property var pebble: null
+
+    SilicaListView {
+        header: PageHeader {
+            title: qsTr("Developer Tools")
+        }
+        model: devMenuModel
+        anchors.fill: parent
+        delegate: ListItem {
+            contentHeight: Theme.itemSizeSmall
+            Row {
+                height: Theme.itemSizeSmall
+                width: parent.width
+                spacing: Theme.paddingSmall
+                Image {
+                        anchors.verticalCenter: parent.verticalCenter
+                        source: "image://theme/icon-s-"+model.icon
+                }
+                Label {
+                    text: model.text
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+            onClicked: {
+                if (model.page) {
+                    pageStack.push(Qt.resolvedUrl(model.page), {pebble: root.pebble})
+                } else if (model.call) {
+                    _menu_calls[model.call]()
+                }
+            }
+        }
+    }
+    property var _menu_calls: {
+        "stop": function(){rockPool.stopService()},
+        "logs": function(){sendLogsDocker.show()}
+    }
 
     //Creating the menu list this way to allow the text field to be translatable (http://askubuntu.com/a/476331)
     ListModel {
@@ -19,97 +50,63 @@ Page {
     Component.onCompleted: {
         populateDevMenu();
     }
-
     function populateDevMenu() {
         devMenuModel.clear();
 
         devMenuModel.append({
-            icon: "camera-app-symbolic",
-            text: i18n.tr("Screenshots"),
-            page: "ScreenshotsPage.qml",
-            dialog: "",
-            color: "gold"
-        });
-        devMenuModel.append({
-            icon: "dialog-warning-symbolic",
-            text: i18n.tr("Report problem"),
+            icon: "developer",
+            text: qsTr("Disable Service"),
             page: "",
-            dialog: sendLogsComponent,
-            color: UbuntuColors.red
+            call: "stop"
         });
         devMenuModel.append({
-            icon: "stock_application",
-            text: i18n.tr("Install app or watchface from file"),
-            page: "ImportPackagePage.qml",
-            dialog: null,
-            color: UbuntuColors.blue
+            icon: "time",
+            text: qsTr("Screenshots"),
+            page: "ScreenshotsPage.qml",
+            call: null
         });
-
+        devMenuModel.append({
+            icon: "task",
+            text: qsTr("Report problem"),
+            page: "",
+            call: "logs"
+        });
+        devMenuModel.append({
+            icon: "device-upload",
+            text: qsTr("Install app or watchface from file"),
+            page: "ImportPackagePage.qml",
+            call: null
+        });
     }
 
-    ColumnLayout {
-        anchors.fill: parent
-
-        Repeater {
-            id: menuRepeater
-            model: devMenuModel
-            delegate: ListItem {
-
-                RowLayout {
-                    anchors.fill: parent
-                    anchors.margins: units.gu(1)
-
-                    UbuntuShape {
-                        Layout.fillHeight: true
-                        Layout.preferredWidth: height
-                        backgroundColor: model.color
-                        Icon {
-                            anchors.fill: parent
-                            anchors.margins: units.gu(.5)
-                            name: model.icon
-                            color: "white"
-                        }
-                    }
-
-
-                    Label {
-                        text: model.text
-                        Layout.fillWidth: true
-                    }
-                }
-
-                onClicked: {
-                    if (model.page) {
-                        pageStack.push(Qt.resolvedUrl(model.page), {pebble: root.pebble})
-                    }
-                    if (model.dialog) {
-                        PopupUtils.open(model.dialog)
-                    }
-                }
+    DockedPanel {
+        id: sendLogsDocker
+        width: parent.width
+        height: content.childrenRect.height
+        dock: Dock.Bottom
+        open: false
+        Column {
+            id: content
+            width: parent.width
+            Label {
+                text: qsTr("Report problem")
+                font.pixelSize: Theme.fontSizeLarge
+                horizontalAlignment: Text.AlignRight
+                width: parent.width
+                color: Theme.secondaryHighlightColor
             }
-        }
-
-        Item {
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-        }
-    }
-
-    Component {
-        id: sendLogsComponent
-        Dialog {
-            id: sendLogsDialog
-            title: i18n.tr("Report problem")
-            ActivityIndicator {
+            BusyIndicator {
                 id: busyIndicator
                 visible: false
                 running: visible
+                width: parent.width
             }
             Label {
-                text: i18n.tr("Preparing logs package...")
+                text: qsTr("Preparing logs package...")
                 visible: busyIndicator.visible
                 horizontalAlignment: Text.AlignHCenter
-                fontSize: "large"
+                width: parent.width
+                font.pixelSize: Theme.fontSizeLarge
             }
 
             Connections {
@@ -117,41 +114,46 @@ Page {
                 onLogsDumped: {
                     if (success) {
                         var filename = "/tmp/pebble.log"
-                        pageStack.push(Qt.resolvedUrl("ContentPeerPickerPage.qml"), {itemName: i18n.tr("pebble.log"),handler: ContentHandler.Share, contentType: ContentType.All, filename: filename })
+                        pageStack.push(Qt.resolvedUrl("ContentPeerPickerPage.qml"), {
+                            itemName: qsTr("pebble.log"),
+                            handler: ContentHandler.Share,
+                            contentType: ContentType.All,
+                            filename: filename
+                        })
                     }
-                    PopupUtils.close(sendLogsDialog)
+                    sendLogsDocker.hide()
                 }
             }
 
             Button {
-                text: i18n.tr("Send rockworkd.log")
-                color: UbuntuColors.blue
+                text: qsTr("Send rockworkd.log")
+                width: parent.width
                 visible: !busyIndicator.visible
                 onClicked: {
                     var filename = homePath + "/.cache/upstart/rockworkd.log"
-                    pageStack.push(Qt.resolvedUrl("ContentPeerPickerPage.qml"), {itemName: i18n.tr("rockworkd.log"),handler: ContentHandler.Share, contentType: ContentType.All, filename: filename })
-                    PopupUtils.close(sendLogsDialog)
+                    pageStack.push(Qt.resolvedUrl("ContentPeerPickerPage.qml"), {itemName: qsTr("rockworkd.log"),handler: ContentHandler.Share, contentType: ContentType.All, filename: filename })
+
+                    sendLogsDocker.hide()
                 }
             }
             Button {
-                text: i18n.tr("Send watch logs")
-                color: UbuntuColors.blue
+                text: qsTr("Send watch logs")
                 visible: !busyIndicator.visible
+                width: parent.width
                 onClicked: {
                     busyIndicator.visible = true
                     root.pebble.dumpLogs("/tmp/pebble.log")
                 }
             }
             Button {
-                text: i18n.tr("Cancel")
-                color: UbuntuColors.red
+                text: qsTr("Cancel")
                 visible: !busyIndicator.visible
+                width: parent.width
                 onClicked: {
-                    PopupUtils.close(sendLogsDialog)
+                    sendLogsDocker.hide()
                 }
             }
         }
     }
-
 }
 

--- a/rockwork/qml/pages/InfoPage.qml
+++ b/rockwork/qml/pages/InfoPage.qml
@@ -20,7 +20,7 @@ Page {
                 width: parent.width
                 spacing: Theme.paddingSmall
                 Image {
-                    source: "artwork/rockwork.svg"
+                    source: "qrc:///artwork/rockwork.svg"
                     height: Theme.iconSizeSmall
                     width: height
                 }

--- a/rockwork/qml/pages/LoadingPage.qml
+++ b/rockwork/qml/pages/LoadingPage.qml
@@ -3,6 +3,7 @@ import Sailfish.Silica 1.0
 
 Page {
     id: loadingComponent
+    property bool wantConnect: true
 
     Column {
         width:parent.width
@@ -18,6 +19,11 @@ Page {
             font.pixelSize: Theme.fontSizeLarge
             text: qsTr("Loading and Connecting...")
         }
+        Button {
+            text: qsTr("Restart Service")
+            onClicked: rockPool.initService()
+            width: parent.width
+        }
     }
     Image {
         id: upgradeIcon
@@ -31,6 +37,7 @@ Page {
             to: 360
             running: upgradeIcon.visible
         }
-        visible: !pebbles.connectedToService
+
+        visible: !pebbles.connectedToService && loadingComponent.status === PageStatus.Active && wantConnect
     }
 }

--- a/rockwork/qml/pages/ScreenshotsPage.qml
+++ b/rockwork/qml/pages/ScreenshotsPage.qml
@@ -11,12 +11,12 @@ Page {
         anchors.fill: parent
         clip: true
 
-        property int columns: 2
+        property int columns: Math.round(width/200)
 
-        cellWidth: width / columns
+        cellWidth: width / columns - Theme.paddingSmall
         cellHeight: cellWidth
 
-        PageHeader {
+        header: PageHeader {
             title: qsTr("Screenshots")
         }
         PullDownMenu {
@@ -28,12 +28,15 @@ Page {
 
         model: root.pebble.screenshots
 
-        delegate: Item {
-            width: grid.cellWidth
-            height: grid.cellHeight
+        delegate: ListItem {
+            //width: grid.cellWidth
+            //height: grid.cellHeight
+            contentWidth: grid.cellWidth
+            contentHeight: grid.cellHeight
             Image {
-                anchors.fill: parent
-                anchors.margins: units.gu(.5)
+                //anchors.fill: parent
+                //anchors.margins: Theme.paddingSmall
+                anchors.centerIn: parent
                 fillMode: Image.PreserveAspectFit
                 source: "file://" + model.filename
             }

--- a/rockwork/qml/rockpool.qml
+++ b/rockwork/qml/rockpool.qml
@@ -33,6 +33,10 @@ ApplicationWindow {
             serviceController.restartService();
         }
     }
+    function stopService() {
+        console.log("Request to stop and disable service");
+        serviceController.stopService()
+    }
 
     function loadStack() {
         if (pebbles.connectedToService) {
@@ -45,6 +49,11 @@ ApplicationWindow {
             }
         } else {
             console.log("Waiting for service")
+            if(curPebble>=0) {
+                pageStack.clear();
+                pageStack.push(initialPage);
+                curPebble = -1;
+            }
         }
     }
     Component.onCompleted: loadStack();

--- a/rockwork/qml/rockpool.qml
+++ b/rockwork/qml/rockpool.qml
@@ -1,8 +1,5 @@
 import QtQuick 2.2
 import Sailfish.Silica 1.0
-//import QtQuick 2.4
-//import QtQuick.Layouts 1.1
-//import Ubuntu.Components 1.3
 import RockPool 1.0
 import "pages"
 
@@ -18,22 +15,23 @@ ApplicationWindow {
 
     ServiceController {
         id: serviceController
-        Component.onCompleted: {
-            if (!serviceController.serviceRunning) {
-                console.log("Service not running. Starting now.");
-                serviceController.startService();
-            }
-            if (pebbles.version !== version) {
-                console.log("Service file version (", version, ") is not equal running service version (", pebbles.version, "). Restarting service.");
-                serviceController.restartService();
-            }
-        }
+        Component.onCompleted: initService()
     }
 
     Pebbles {
         id: pebbles
         onCountChanged: loadStack()
         onConnectedToServiceChanged: loadStack();
+    }
+    function initService() {
+        if (!serviceController.serviceRunning) {
+            console.log("Service not running. Starting now.");
+            serviceController.startService();
+        }
+        if (pebbles.version !== version) {
+            console.log("Service file version (", version, ") is not equal running service version (", pebbles.version, "). Restarting service.");
+            serviceController.restartService();
+        }
     }
 
     function loadStack() {

--- a/rockwork/servicecontrol.cpp
+++ b/rockwork/servicecontrol.cpp
@@ -62,6 +62,7 @@ bool ServiceControl::startService()
         return false;
     } else {
         systemd->call("Reload");
+        systemd->call("StartUnit", ROCKPOOLD_SYSTEMD_UNIT, "replace");
         return true;
     }
 }
@@ -69,6 +70,7 @@ bool ServiceControl::startService()
 bool ServiceControl::stopService()
 {
     QDBusError reply;
+    systemd->call("StopUnit", ROCKPOOLD_SYSTEMD_UNIT, "replace");
     systemd->call("DisableUnitFiles", QStringList() << ROCKPOOLD_SYSTEMD_UNIT, false);
     if (reply.isValid()) {
         qWarning() << reply.message();


### PR DESCRIPTION
The 4 patches represent following fixes
* Service AutoStart from the app - currently it's only enabled/disabled but not actually started/stoped
* AppStore search - a missing attribute during clanup
* AppSettings List - introduced floating list selector component to pick dropbox values
* DeveloperPage - the page is cleaned up and is displayable, however File Picker is still missing hence functionality is still partial. Also added Disable Service to the devel page. At the moment there's no ability to switch it off (apart of cli) 