### PR TITLE
Multiple fixes and updates, BT, UI and translations

### DIFF
--- a/rockwork/main.cpp
+++ b/rockwork/main.cpp
@@ -21,6 +21,10 @@ int main(int argc, char *argv[])
     app->setApplicationName("pebble");
     app->setOrganizationName("");
 
+    QTranslator i18n;
+    i18n.load("translations_"+QLocale::system().name(),"/usr/share/rockpool/translations");
+    app->installTranslator(&i18n);
+
     qmlRegisterUncreatableType<Pebble>("RockPool", 1, 0, "Pebble", "Get them from the model");
     qmlRegisterUncreatableType<ApplicationsModel>("RockPool", 1, 0, "ApplicationsModel", "Get them from a Pebble object");
     qmlRegisterUncreatableType<AppItem>("RockPool", 1, 0, "AppItem", "Get them from an ApplicationsModel");

--- a/rockwork/pebble.cpp
+++ b/rockwork/pebble.cpp
@@ -15,6 +15,7 @@ Pebble::Pebble(const QDBusObjectPath &path, QObject *parent):
     m_installedApps = new ApplicationsModel(this);
     connect(m_installedApps, &ApplicationsModel::appsSorted, this, &Pebble::appsSorted);
     m_installedWatchfaces = new ApplicationsModel(this);
+    connect(m_installedWatchfaces, &ApplicationsModel::appsSorted, this, &Pebble::appsSorted);
     m_screenshotModel = new ScreenshotModel(this);
 
     QDBusConnection::sessionBus().connect("org.rockwork", path.path(), "org.rockwork.Pebble", "Connected", this, SLOT(pebbleConnected()));

--- a/rockwork/qml/pages/AppSettingsPage.qml
+++ b/rockwork/qml/pages/AppSettingsPage.qml
@@ -4,7 +4,7 @@ import QtWebKit 3.0
 //import QtWebKit.experimental 1.0
 
 Page {
-    id: settings
+    id: appSettings
 
     property string uuid;
     property string url;
@@ -13,7 +13,7 @@ Page {
         id: webview
         anchors.fill: parent
 
-        url: settings.url
+        url: appSettings.url
         /*header: Label {
             text: qsTr("App Settings")
             width: parent.width
@@ -29,14 +29,13 @@ Page {
             var url = request.url.toString();
             console.log(url, url.substring(0, 16));
             if (url.substring(0, 16) == 'pebblejs://close') {
-                pebble.configurationClosed(settings.uuid, url);
+                pebble.configurationClosed(appSettings.uuid, url);
                 request.action = WebView.IgnoreRequest;
                 pageStack.pop();
             }
         }
-        experimental.preferences.webGLEnabled: true
-        //experimental.preferences.webAudioEnabled: true
-        //experimental.preferredMinimumContentsWidth: 980
+        //experimental.deviceHeight:appSettings.height
+        experimental.transparentBackground: true
         experimental.itemSelector: Component {
             id: selBox
             Rectangle {
@@ -72,6 +71,20 @@ Page {
         //experimental.alertDialog: AlertDialog { }
         //experimental.confirmDialog: ConfirmDialog { }
         //experimental.promptDialog: PromptDialog { }
-
+        experimental.colorChooser: Component {
+            id: colBox
+            ColorPicker {
+                anchors.fill: webview
+                onColorChanged: { console.log("The color is",color); model.reject() }
+            }
+        }
+        onLoadingChanged: {busyId.running = webview.loading}
+    }
+    BusyIndicator {
+        id: busyId
+        anchors.centerIn: parent
+        running: true
+        visible: running
+        size: BusyIndicatorSize.Large
     }
 }

--- a/rockwork/qml/pages/AppStoreDetailsPage.qml
+++ b/rockwork/qml/pages/AppStoreDetailsPage.qml
@@ -72,7 +72,7 @@ Page {
                         anchors.centerIn: parent
                         spacing: Theme.paddingSmall
                         Image {
-                            source: "image://theme/icon-m-" + (root.app.isWatchFace ? "wath" : "toy")
+                            source: "image://theme/icon-m-" + (root.app.isWatchFace ? "watch" : "toy")
                             height: parent.height
                             width: height
                         }
@@ -155,7 +155,7 @@ Page {
                             id: maskFace
                             color: "blue"
                             anchors.centerIn: parent
-                            anchors.horizontalCenterOffset: Theme.paddingSmall
+                            anchors.horizontalCenterOffset: Theme.paddingSmall/2
                             height: parent.height
                             width: screenshotsItem.isRound ? height : height * 0.86
                             radius: screenshotsItem.isRound ? height / 2 : 0

--- a/rockwork/qml/pages/AppStorePage.qml
+++ b/rockwork/qml/pages/AppStorePage.qml
@@ -38,6 +38,15 @@ Page {
         header: PageHeader {
             title: (catName)? catName: (showWatchApps ? qsTr("Add new watchapp") : qsTr("Add new watchface"))
         }
+        ViewPlaceholder {
+            enabled: parent.count===0
+            anchors.fill: parent
+            BusyIndicator {
+                anchors.centerIn: parent
+                running: parent.enabled
+            }
+        }
+
         model: ApplicationsFilterModel {
             id: appsFilterModel
             model: client.model
@@ -183,7 +192,6 @@ Page {
                 searchTextField.focus = true;
             }
         }
-
         TextField {
             id: searchTextField
             anchors { top: parent.top; left: parent.left }

--- a/rockwork/qml/pages/AppStorePage.qml
+++ b/rockwork/qml/pages/AppStorePage.qml
@@ -38,14 +38,6 @@ Page {
         header: PageHeader {
             title: (catName)? catName: (showWatchApps ? qsTr("Add new watchapp") : qsTr("Add new watchface"))
         }
-        ViewPlaceholder {
-            enabled: parent.count===0
-            anchors.fill: parent
-            BusyIndicator {
-                anchors.centerIn: parent
-                running: parent.enabled
-            }
-        }
 
         model: ApplicationsFilterModel {
             id: appsFilterModel
@@ -179,6 +171,12 @@ Page {
                 pageStack.push(Qt.resolvedUrl("AppStoreDetailsPage.qml"), {app: appsFilterModel.get(index), pebble: root.pebble})
             }
         }
+    }
+    BusyIndicator {
+        anchors.centerIn: parent
+        running: client.busy
+        size: BusyIndicatorSize.Large
+        visible: running
     }
     DockedPanel {
         id: searchField

--- a/rockwork/qml/pages/DeveloperToolsPage.qml
+++ b/rockwork/qml/pages/DeveloperToolsPage.qml
@@ -115,7 +115,7 @@ Page {
                     if (success) {
                         var filename = "/tmp/pebble.log"
                         pageStack.push(Qt.resolvedUrl("ContentPeerPickerPage.qml"), {
-                            itemName: qsTr("pebble.log"),
+                            itemName: "pebble.log",
                             handler: ContentHandler.Share,
                             contentType: ContentType.All,
                             filename: filename
@@ -126,12 +126,12 @@ Page {
             }
 
             Button {
-                text: qsTr("Send rockworkd.log")
+                text: qsTr("Send")+"rockworkd.log"
                 width: parent.width
                 visible: !busyIndicator.visible
                 onClicked: {
                     var filename = homePath + "/.cache/upstart/rockworkd.log"
-                    pageStack.push(Qt.resolvedUrl("ContentPeerPickerPage.qml"), {itemName: qsTr("rockworkd.log"),handler: ContentHandler.Share, contentType: ContentType.All, filename: filename })
+                    pageStack.push(Qt.resolvedUrl("ContentPeerPickerPage.qml"), {itemName: "rockworkd.log",handler: ContentHandler.Share, contentType: ContentType.All, filename: filename })
 
                     sendLogsDocker.hide()
                 }

--- a/rockwork/qml/pages/MainMenuPage.qml
+++ b/rockwork/qml/pages/MainMenuPage.qml
@@ -178,13 +178,12 @@ Page {
                         id: menuRepeater
                         model: root.pebble.connected && !root.pebble.recovery && !root.pebble.upgradingFirmware ? mainMenuModel : null
                         delegate: ListItem {
-                            contentHeight: Theme.iconSizeMedium + Theme.paddingSmall
+                            contentHeight: Theme.iconSizeMedium + Theme.paddingSmall*2
                             Row {
                                 height: Theme.iconSizeMedium
                                 anchors.verticalCenter: parent.verticalCenter
+                                spacing: Theme.paddingSmall
                                 Image {
-                                    width: Theme.iconSizeMedium
-                                    height: Theme.iconSizeMedium
                                     source: "image://theme/" + model.icon
                                     anchors.verticalCenter: parent.verticalCenter
                                 }
@@ -236,31 +235,31 @@ Page {
         mainMenuModel.clear()
 
         mainMenuModel.append({
-                                 icon: "icon-s-message",
+                                 icon: "icon-m-alarm",
                                  text: qsTr("Manage notifications"),
                                  page: "NotificationsPage.qml"
                              })
         mainMenuModel.append({
-                                 icon: "icon-s-installed",
+                                 icon: "icon-m-toy",
                                  text: qsTr("Manage Apps"),
                                  page: "InstalledAppsPage.qml",
                                  showWatchApps: true
                              })
         mainMenuModel.append({
-                                 icon: "icon-s-time",
+                                 icon: "icon-m-watch",
                                  text: qsTr("Manage Watchfaces"),
                                  page: "InstalledAppsPage.qml",
                                  showWatchFaces: true
                              })
         mainMenuModel.append({
-                                 icon: "icon-s-setting",
+                                 icon: "icon-m-developer-mode",
                                  text: qsTr("Settings"),
                                  page: "SettingsPage.qml",
                                  showWatchFaces: true
                              })
 
         mainMenuModel.append({
-                                 icon: "icon-s-update",
+                                 icon: "icon-m-up",
                                  text: qsTr("Manage Firmware"),
                                  page: "FirmwareUpgradePage.qml"
                              })

--- a/rockwork/qml/pages/MainMenuPage.qml
+++ b/rockwork/qml/pages/MainMenuPage.qml
@@ -151,9 +151,9 @@ Page {
                     }
 
                     Button {
-                        text: qsTr("Open System Settings")
+                        text: qsTr("Open Bluetooth Settings")
                         visible: !root.pebble.connected
-                        onClicked: Qt.openUrlExternally("settings://system/bluetooth")
+                        onClicked: rockPool.startBT()
                         anchors.horizontalCenter: parent.horizontalCenter
                     }
 

--- a/rockwork/qml/pages/PebblesPage.qml
+++ b/rockwork/qml/pages/PebblesPage.qml
@@ -11,8 +11,10 @@ Page {
         }
         PullDownMenu {
             MenuItem {
-                text: qsTr("Settings")
-                onClicked: Qt.openUrlExternally("settings://system/bluetooth");
+                text: qsTr("Bluetooth Settings")
+                onClicked: rockPool.startBT()
+                enabled: pebbles.count>0
+                visible: enabled
             }
             /*MenuItem {
                 text: "Refresh"
@@ -61,10 +63,10 @@ Page {
         }
 
         Button {
-            text: qsTr("Open System Settings")
+            text: qsTr("Open Bluetooth Settings")
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.bottom: parent.bottom
-            onClicked: Qt.openUrlExternally("settings://system/bluetooth")
+            onClicked: rockPool.startBT()
         }
     }
 }

--- a/rockwork/qml/pages/SettingsPage.qml
+++ b/rockwork/qml/pages/SettingsPage.qml
@@ -30,8 +30,7 @@ Page {
                 value: (root.pebble.imperialUnits) ? 1 : 0
             }
             Separator {
-                width: parent.width * 0.7
-                anchors.horizontalCenter: parent.horizontalCenter
+                width: parent.width
                 height: Theme.paddingSmall
                 color: Theme.secondaryHighlightColor
             }

--- a/rockwork/qml/pages/SystemAppIcon.qml
+++ b/rockwork/qml/pages/SystemAppIcon.qml
@@ -7,7 +7,7 @@ Item {
     property string iconSource: ""
 
     Image {
-        anchors.fill: parent
+        anchors.verticalCenter: parent.verticalCenter
         visible: parent.isSystemApp
         source: {
             var icon = "";
@@ -25,17 +25,17 @@ Item {
                 icon = "music";
                 break;
             case "{b2cae818-10f8-46df-ad2b-98ad2254a3c1}":
-                icon = "notifications";
+                icon = "alarm";
                 break;
             case "{67a32d95-ef69-46d4-a0b9-854cc62f97f9}":
-                icon = "alarm";
+                icon = "timer";
                 break;
             case "{8f3c8686-31a1-4f5f-91f5-01600c9bdc59}":
                 icon = "clock"
             }
             if (icon)
                 return "image://theme/icon-m-" + icon
-            return ""
+            return "image://theme/icon-m-other"
         }
     }
 

--- a/rockwork/qml/rockpool.qml
+++ b/rockwork/qml/rockpool.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.2
 import Sailfish.Silica 1.0
 import RockPool 1.0
+import org.nemomobile.dbus 2.0
 import "pages"
 
 /*!
@@ -23,6 +24,24 @@ ApplicationWindow {
         onCountChanged: loadStack()
         onConnectedToServiceChanged: loadStack();
     }
+    DBusInterface {
+        id: lipstick
+        service: "org.nemomobile.lipstick"
+        path: "/LauncherModel"
+        iface: "org.nemomobile.lipstick.LauncherModel"
+    }
+    DBusInterface {
+        id: jolla
+        service: "com.jolla.settings"
+        path: "/com/jolla/settings/ui"
+        iface: "com.jolla.settings.ui"
+    }
+    function startBT() {
+        lipstick.typedCall("notifyLaunching",[{"type":"s","value":"jolla-settings.desktop"}],
+                           function(r){jolla.call("showPage",["system_settings/connectivity/bluetooth"])},
+                           function(e){console.log("Error",e)})
+    }
+
     function initService() {
         if (!pebbles.connectedToService && !serviceController.serviceRunning) {
             console.log("Service not running. Starting now.");

--- a/rockwork/rockwork.pro
+++ b/rockwork/rockwork.pro
@@ -35,7 +35,7 @@ QML_FILES += $$files(qml/cover/*.qml,true)
 
 CONF_FILES +=  rockpool.png \
                rockpool.desktop \
-               translations/*.ts
+               $$files(translations/*.ts,true)
 
 #show all the files in QtCreator
 OTHER_FILES += $${QML_FILES} \
@@ -59,8 +59,8 @@ DISTFILES += \
     qml/pages/LoadingPage.qml
 
 # Translations
+lupdate_only {
+    SOURCES += QML_FILES
+}
 CONFIG += sailfishapp_i18n
-TRANSLATIONS += translations/*.ts
-
-
-
+TRANSLATIONS += $$files(translations/*.ts,true)

--- a/rockwork/translations/rockpool.ts
+++ b/rockwork/translations/rockpool.ts
@@ -4,7 +4,7 @@
 <context>
     <name>AppSettingsPage</name>
     <message>
-        <location filename="../qml/pages/AppSettingsPage.qml" line="47"/>
+        <location filename="../qml/pages/AppSettingsPage.qml" line="46"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -55,12 +55,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AppStorePage.qml" line="82"/>
+        <location filename="../qml/pages/AppStorePage.qml" line="83"/>
         <source>See all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/AppStorePage.qml" line="191"/>
+        <location filename="../qml/pages/AppStorePage.qml" line="197"/>
         <source>Search app or watchface</source>
         <translation type="unfinished"></translation>
     </message>
@@ -112,18 +112,8 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="118"/>
-        <source>pebble.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../qml/pages/DeveloperToolsPage.qml" line="129"/>
-        <source>Send rockworkd.log</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="134"/>
-        <source>rockworkd.log</source>
+        <source>Send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -402,7 +392,7 @@
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="154"/>
-        <source>Open System Settings</source>
+        <source>Open Bluetooth Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -416,27 +406,27 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="240"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="239"/>
         <source>Manage notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="245"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="244"/>
         <source>Manage Apps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="251"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="250"/>
         <source>Manage Watchfaces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="257"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="256"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="264"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="263"/>
         <source>Manage Firmware</source>
         <translation type="unfinished"></translation>
     </message>
@@ -468,27 +458,27 @@
     </message>
     <message>
         <location filename="../qml/pages/PebblesPage.qml" line="14"/>
-        <source>Settings</source>
+        <source>Bluetooth Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <location filename="../qml/pages/PebblesPage.qml" line="37"/>
         <source>Connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <location filename="../qml/pages/PebblesPage.qml" line="37"/>
         <source>Disconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="55"/>
+        <location filename="../qml/pages/PebblesPage.qml" line="57"/>
         <source>No Pebble smartwatches configured yet. Please connect your Pebble smartwatch using System Settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="64"/>
-        <source>Open System Settings</source>
+        <location filename="../qml/pages/PebblesPage.qml" line="66"/>
+        <source>Open Bluetooth Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -549,7 +539,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SettingsPage.qml" line="40"/>
+        <location filename="../qml/pages/SettingsPage.qml" line="39"/>
         <source>Sync calendar to timeline</source>
         <translation type="unfinished"></translation>
     </message>

--- a/rockwork/translations/rockpool_ru.ts
+++ b/rockwork/translations/rockpool_ru.ts
@@ -1,0 +1,547 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="ru" sourcelanguage="en">
+<context>
+    <name>AppSettingsPage</name>
+    <message>
+        <location filename="../qml/pages/AppSettingsPage.qml" line="46"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+</context>
+<context>
+    <name>AppStoreDetailsPage</name>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="170"/>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="191"/>
+        <source>Developer</source>
+        <translation>Разработчик</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="196"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="246"/>
+        <source>Install</source>
+        <translation>Установить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="246"/>
+        <source>Installing...</source>
+        <translation>Ставится...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="246"/>
+        <source>Installed</source>
+        <translation>Установлено</translation>
+    </message>
+</context>
+<context>
+    <name>AppStorePage</name>
+    <message>
+        <location filename="../qml/pages/AppStorePage.qml" line="39"/>
+        <source>Add new watchapp</source>
+        <translation>Добавить приложение</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStorePage.qml" line="39"/>
+        <source>Add new watchface</source>
+        <translation>Добавить циферблат</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStorePage.qml" line="83"/>
+        <source>See all</source>
+        <translation>Показать Все</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStorePage.qml" line="197"/>
+        <source>Search app or watchface</source>
+        <translation>Поиск публикации</translation>
+    </message>
+</context>
+<context>
+    <name>CoverPage</name>
+    <message>
+        <location filename="../qml/cover/CoverPage.qml" line="27"/>
+        <source>connected</source>
+        <translation>Подключен</translation>
+    </message>
+    <message>
+        <location filename="../qml/cover/CoverPage.qml" line="27"/>
+        <source>disconnected</source>
+        <translation>Отключен</translation>
+    </message>
+</context>
+<context>
+    <name>DeveloperToolsPage</name>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="11"/>
+        <source>Developer Tools</source>
+        <translation>Инструменты Разработчика</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="58"/>
+        <source>Disable Service</source>
+        <translation>Выключить Сервис</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="64"/>
+        <source>Screenshots</source>
+        <translation>Снимки Экрана</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="70"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="92"/>
+        <source>Report problem</source>
+        <translation>Сообщить о Проблеме</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="76"/>
+        <source>Install app or watchface from file</source>
+        <translation>Установить приложение из файла</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="105"/>
+        <source>Preparing logs package...</source>
+        <translation>Подготовка пакета журналов...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="129"/>
+        <source>Send</source>
+        <translation>Отправить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="140"/>
+        <source>Send watch logs</source>
+        <translation>Послать журнал с часов</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="149"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+</context>
+<context>
+    <name>FirmwareUpgradePage</name>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="15"/>
+        <source>Firmware upgrade</source>
+        <translation>Обновление прошивки</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="18"/>
+        <source>Currently installed firmware: %1</source>
+        <translation>Версия текуще прошивки: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="24"/>
+        <source>A new firmware upgrade is available for your Pebble smartwatch.</source>
+        <translation>Доступно обновление прошивки для ваших часов Pebble.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="32"/>
+        <source>Candidate firmware version: %1</source>
+        <translation>Доступная версия прошивки: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="39"/>
+        <source>Release Notes: %1</source>
+        <translation>Замечания к версии: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="46"/>
+        <source>Important:</source>
+        <translation>Важно:</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="46"/>
+        <source>This update will also upgrade recovery data. Make sure your Pebble smartwarch is connected to a power adapter.</source>
+        <translation>Это обновление также обновит оболочку аварийного восстановления. Пожалуйста убедитесь, что ваш Pebble подключен к источнику питания.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="53"/>
+        <source>Upgrade now</source>
+        <translation>Обновить немедля</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="53"/>
+        <source>Firmware is Up-To-Date</source>
+        <translation>У вас самая свежая прошивка</translation>
+    </message>
+</context>
+<context>
+    <name>HealthSettingsDialog</name>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="13"/>
+        <source>Health settings</source>
+        <translation>Фитнес-настройки</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="14"/>
+        <source>OK</source>
+        <translation>Принять</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="16"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="20"/>
+        <source>Health app enabled</source>
+        <translation>Фитнес-приложение включено</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="26"/>
+        <source>Age</source>
+        <translation>Возраст</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="37"/>
+        <source>Height (cm)</source>
+        <translation>Рост (см)</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="47"/>
+        <source>Weight (kg)</source>
+        <translation>Вес (кг)</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="58"/>
+        <source>Gender</source>
+        <translation>Пол</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="59"/>
+        <source>Female</source>
+        <translation>Женский</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="59"/>
+        <source>Male</source>
+        <translation>Мужской</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="67"/>
+        <source>I want to be more active</source>
+        <translation>Желаю больше двигаться</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="68"/>
+        <source>More Active</source>
+        <translation>Быть активней</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="74"/>
+        <source>I want to sleep more</source>
+        <translation>Желаю больше высыпаться</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="75"/>
+        <source>Sleep More</source>
+        <translation>Спать дольше</translation>
+    </message>
+</context>
+<context>
+    <name>ImportPackagePage</name>
+    <message>
+        <location filename="../qml/pages/ImportPackagePage.qml" line="8"/>
+        <source>Import watchapp or watchface</source>
+        <translation>Импортировать приложение или циферблат</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ImportPackagePage.qml" line="30"/>
+        <source>Import File?</source>
+        <translation>Импортировать?</translation>
+    </message>
+</context>
+<context>
+    <name>InfoPage</name>
+    <message>
+        <location filename="../qml/pages/InfoPage.qml" line="29"/>
+        <source>Version %1</source>
+        <translation>Версия %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InfoPage.qml" line="42"/>
+        <source>Legal</source>
+        <translation>Правовая информация</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InfoPage.qml" line="68"/>
+        <source>This application is neither affiliated with nor endorsed by Pebble Technology Corp.</source>
+        <translation>Данное приложение никоим образом не имеет отношения к Pebble Technology Corp. не являясь ни оффициальной ни рекоммендованной компанией оболочкой.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InfoPage.qml" line="78"/>
+        <source>Pebble is a trademark of Pebble Technology Corp.</source>
+        <translation>Pebble является регестрированной торговой маркой Pebble Technology Corp.</translation>
+    </message>
+</context>
+<context>
+    <name>InstalledAppDelegate</name>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="27"/>
+        <source>Launch</source>
+        <translation>Запустить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="31"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="36"/>
+        <source>Delete</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="39"/>
+        <source>Really Delete?</source>
+        <translation>Действительно Удалить?</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="45"/>
+        <source>Move Up</source>
+        <translation>Подвинуть Вверх</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="50"/>
+        <source>Move Down</source>
+        <translation>Подвинуть Вниз</translation>
+    </message>
+</context>
+<context>
+    <name>InstalledAppsPage</name>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="18"/>
+        <source>Add New</source>
+        <translation>Добавить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <source>Apps &amp; Watchfaces</source>
+        <translation>Приложения и Циферблаты</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <source>Apps</source>
+        <translation>Приложения</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <source>Watchfaces</source>
+        <translation>Циферблаты</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="74"/>
+        <source>Save Apps Order</source>
+        <translation>Сохранить Порядок Пакетов</translation>
+    </message>
+</context>
+<context>
+    <name>LoadingPage</name>
+    <message>
+        <location filename="../qml/pages/LoadingPage.qml" line="20"/>
+        <source>Loading and Connecting...</source>
+        <translation>Загрузка и Подключение...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/LoadingPage.qml" line="23"/>
+        <source>Restart Service</source>
+        <translation>Перезапустить Сервис</translation>
+    </message>
+</context>
+<context>
+    <name>MainMenuPage</name>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="19"/>
+        <source>About</source>
+        <translation>О Программе</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="25"/>
+        <source>Developer tools</source>
+        <translation>Инструменты Разработчика</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="112"/>
+        <source>Connected</source>
+        <translation>Подключен</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="112"/>
+        <source>Disconnected</source>
+        <translation>Отключен</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="131"/>
+        <source>Upgrading...</source>
+        <translation>Обновление...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="144"/>
+        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
+        <translation>Ваши часы Pebble в данный момент отключены. Пожалуйста убедитесь чтто они включены, находятся в пределах досягаемости и добавлены в системных настройках Bluetooth.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="154"/>
+        <source>Open System Settings</source>
+        <translation>Открыть Системные Настройки</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="161"/>
+        <source>Your Pebble smartwatch is in factory mode and needs to be initialized.</source>
+        <translation>Ваши часы Pebble находятся в специальном режиме и требуют инициализации.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="170"/>
+        <source>Initialize Pebble</source>
+        <translation>Инициализировать Pebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="239"/>
+        <source>Manage notifications</source>
+        <translation>Управление Уведомлениями</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="244"/>
+        <source>Manage Apps</source>
+        <translation>Управление Приложениями</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="250"/>
+        <source>Manage Watchfaces</source>
+        <translation>Управление Циферблатами</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="256"/>
+        <source>Settings</source>
+        <translation>Системные Настройки</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="263"/>
+        <source>Manage Firmware</source>
+        <translation>Управление Прошивкой</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationsPage</name>
+    <message>
+        <location filename="../qml/pages/NotificationsPage.qml" line="15"/>
+        <source>Notifications</source>
+        <translation>Уведомления</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/NotificationsPage.qml" line="18"/>
+        <source>Entries here will be added as notifications appear on the phone. Selected notifications will be shown on your Pebble smartwatch.</source>
+        <translation>Категории уведомлений ниже будут появляться по мере их поступления с телефона. Выбранные категории будут появляться на ваших часах Pebble.</translation>
+    </message>
+</context>
+<context>
+    <name>PebblesPage</name>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="9"/>
+        <source>RockPool</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="10"/>
+        <source>Manage Pebble Watches</source>
+        <translation>Управление часами Pebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="14"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <source>Connected</source>
+        <translation>Подключено</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <source>Disconnected</source>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="55"/>
+        <source>No Pebble smartwatches configured yet. Please connect your Pebble smartwatch using System Settings.</source>
+        <translation>Отсутствует конфигурация каких либо часов Pebble. Пожалуйста подключите часы Pebble в настройках Системы.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="64"/>
+        <source>Open System Settings</source>
+        <translation>Открыть Настройки Системы</translation>
+    </message>
+</context>
+<context>
+    <name>ScreenshotsPage</name>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="20"/>
+        <source>Screenshots</source>
+        <translation>Снимки Экрана</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="24"/>
+        <source>Take Screenshot</source>
+        <translation>Сделать Снимок</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="46"/>
+        <source>Share</source>
+        <translation>Отправить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="48"/>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="57"/>
+        <source>Pebble screenshot</source>
+        <translation>Снимок экрана Pebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="55"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="64"/>
+        <source>Delete</source>
+        <translation>Удалить</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsPage</name>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="22"/>
+        <source>Distance Units</source>
+        <translation>Еденицы длинны</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="23"/>
+        <source>Metric</source>
+        <translation>Метрические</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="23"/>
+        <source>Imperial</source>
+        <translation>Британские</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="39"/>
+        <source>Sync calendar to timeline</source>
+        <translation>Синхронизировать Календарь с лентой сообщений</translation>
+    </message>
+</context>
+</TS>

--- a/rockwork/translations/rockpool_ru.ts
+++ b/rockwork/translations/rockpool_ru.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="ru" sourcelanguage="en">
+<TS version="2.1" language="ru" sourcelanguage="en">
 <context>
     <name>AppSettingsPage</name>
     <message>
@@ -137,7 +137,7 @@
     <message>
         <location filename="../qml/pages/FirmwareUpgradePage.qml" line="18"/>
         <source>Currently installed firmware: %1</source>
-        <translation>Версия текуще прошивки: %1</translation>
+        <translation>Версия текущей прошивки: %1</translation>
     </message>
     <message>
         <location filename="../qml/pages/FirmwareUpgradePage.qml" line="24"/>
@@ -281,7 +281,7 @@
     <message>
         <location filename="../qml/pages/InfoPage.qml" line="78"/>
         <source>Pebble is a trademark of Pebble Technology Corp.</source>
-        <translation>Pebble является регестрированной торговой маркой Pebble Technology Corp.</translation>
+        <translation>Pebble является регистрированной торговой маркой Pebble Technology Corp.</translation>
     </message>
 </context>
 <context>
@@ -388,12 +388,12 @@
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="144"/>
         <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
-        <translation>Ваши часы Pebble в данный момент отключены. Пожалуйста убедитесь чтто они включены, находятся в пределах досягаемости и добавлены в системных настройках Bluetooth.</translation>
+        <translation>Ваши часы Pebble в данный момент отключены. Пожалуйста убедитесь что они включены, находятся в пределах досягаемости и добавлены в системных настройках Bluetooth.</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="154"/>
-        <source>Open System Settings</source>
-        <translation>Открыть Системные Настройки</translation>
+        <source>Open Bluetooth Settings</source>
+        <translation>Открыть Настройки Bluetooth</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="161"/>
@@ -458,28 +458,28 @@
     </message>
     <message>
         <location filename="../qml/pages/PebblesPage.qml" line="14"/>
-        <source>Settings</source>
-        <translation>Настройки</translation>
+        <source>Bluetooth Settings</source>
+        <translation>Настройки Bluetooth</translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <location filename="../qml/pages/PebblesPage.qml" line="37"/>
         <source>Connected</source>
         <translation>Подключено</translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <location filename="../qml/pages/PebblesPage.qml" line="37"/>
         <source>Disconnected</source>
         <translation>Отключено</translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="55"/>
+        <location filename="../qml/pages/PebblesPage.qml" line="57"/>
         <source>No Pebble smartwatches configured yet. Please connect your Pebble smartwatch using System Settings.</source>
         <translation>Отсутствует конфигурация каких либо часов Pebble. Пожалуйста подключите часы Pebble в настройках Системы.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="64"/>
-        <source>Open System Settings</source>
-        <translation>Открыть Настройки Системы</translation>
+        <location filename="../qml/pages/PebblesPage.qml" line="66"/>
+        <source>Open Bluetooth Settings</source>
+        <translation>Открыть Настройки Bluetooth</translation>
     </message>
 </context>
 <context>

--- a/rockwork/translations/rockpool_uk.ts
+++ b/rockwork/translations/rockpool_uk.ts
@@ -1,0 +1,548 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="uk" sourcelanguage="en">
+<context>
+    <name>AppSettingsPage</name>
+    <message>
+        <location filename="../qml/pages/AppSettingsPage.qml" line="46"/>
+        <source>Cancel</source>
+        <translation>Відмінити</translation>
+    </message>
+</context>
+<context>
+    <name>AppStoreDetailsPage</name>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="170"/>
+        <source>Description</source>
+        <translation>Опис</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="191"/>
+        <source>Developer</source>
+        <translation>Розробник</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="196"/>
+        <source>Version</source>
+        <translation>Версія</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="246"/>
+        <source>Install</source>
+        <translation>Встановити</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="246"/>
+        <source>Installing...</source>
+        <translation>Ставиться...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStoreDetailsPage.qml" line="246"/>
+        <source>Installed</source>
+        <translation>Встановлено</translation>
+    </message>
+</context>
+<context>
+    <name>AppStorePage</name>
+    <message>
+        <location filename="../qml/pages/AppStorePage.qml" line="39"/>
+        <source>Add new watchapp</source>
+        <translation>Добавити додаток</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStorePage.qml" line="39"/>
+        <source>Add new watchface</source>
+        <translation>Добавити циферблат</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStorePage.qml" line="83"/>
+        <source>See all</source>
+        <translation>Показати Всі</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppStorePage.qml" line="197"/>
+        <source>Search app or watchface</source>
+        <translation>Пошук додатку або циферблату</translation>
+    </message>
+</context>
+<context>
+    <name>CoverPage</name>
+    <message>
+        <location filename="../qml/cover/CoverPage.qml" line="27"/>
+        <source>connected</source>
+        <translation>Підключено</translation>
+    </message>
+    <message>
+        <location filename="../qml/cover/CoverPage.qml" line="27"/>
+        <source>disconnected</source>
+        <translation>Відключено</translation>
+    </message>
+</context>
+<context>
+    <name>DeveloperToolsPage</name>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="11"/>
+        <source>Developer Tools</source>
+        <translation>Інструменти Розробника</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="58"/>
+        <source>Disable Service</source>
+        <translation>Відключити Сервіс</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="64"/>
+        <source>Screenshots</source>
+        <translation>Знімки Екрану</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="70"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="92"/>
+        <source>Report problem</source>
+        <translation>Повідомити про Проблему</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="76"/>
+        <source>Install app or watchface from file</source>
+        <translation>Встановити додаток з файлу</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="105"/>
+        <source>Preparing logs package...</source>
+        <translation>Підготовка пакету журналів...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="129"/>
+        <source>Send</source>
+        <translation>Відіслати</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="140"/>
+        <source>Send watch logs</source>
+        <translation>Відіслати журнал з годинника</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="149"/>
+        <source>Cancel</source>
+        <translation>Відмінити</translation>
+    </message>
+</context>
+<context>
+    <name>FirmwareUpgradePage</name>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="15"/>
+        <source>Firmware upgrade</source>
+        <translation>Оновлення прошивки</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="18"/>
+        <source>Currently installed firmware: %1</source>
+        <translation>Версія поточної прошивки: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="24"/>
+        <source>A new firmware upgrade is available for your Pebble smartwatch.</source>
+        <translation>Доступне оновлення прошивки для вашого годинника Pebble.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="32"/>
+        <source>Candidate firmware version: %1</source>
+        <translation>Доступна версія прошивки: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="39"/>
+        <source>Release Notes: %1</source>
+        <translation>Зауваження до версії: %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="46"/>
+        <source>Important:</source>
+        <translation>Важливо:</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="46"/>
+        <source>This update will also upgrade recovery data. Make sure your Pebble smartwarch is connected to a power adapter.</source>
+        <translation>Це оновлення також оновить оболонку аварійного відновлення. Будьласка перевірте що ваш Pebble підключен до джерела живлення.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="53"/>
+        <source>Upgrade now</source>
+        <translation>Оновити зараз</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/FirmwareUpgradePage.qml" line="53"/>
+        <source>Firmware is Up-To-Date</source>
+        <translation>Ввас сама свіжа прошивка</translation>
+    </message>
+</context>
+<context>
+    <name>HealthSettingsDialog</name>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="13"/>
+        <source>Health settings</source>
+        <translation>Налаштування Оздоровлення</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="14"/>
+        <source>OK</source>
+        <translation>Добре</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="16"/>
+        <source>Cancel</source>
+        <translation>Скасувати</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="20"/>
+        <source>Health app enabled</source>
+        <translation>Додаток оздоровлення увімкнутий</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="26"/>
+        <source>Age</source>
+        <translation>Вік</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="37"/>
+        <source>Height (cm)</source>
+        <translation>Зріст (см)</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="47"/>
+        <source>Weight (kg)</source>
+        <translation>Вага (кг)</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="58"/>
+        <source>Gender</source>
+        <translation>Стать</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="59"/>
+        <source>Female</source>
+        <translation>Жіночий</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="59"/>
+        <source>Male</source>
+        <translation>Чоловічий</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="67"/>
+        <source>I want to be more active</source>
+        <translation>Бажаю більш рухатися</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="68"/>
+        <source>More Active</source>
+        <translation>Більш активний</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="74"/>
+        <source>I want to sleep more</source>
+        <translation>Бажаю більше спати</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/HealthSettingsDialog.qml" line="75"/>
+        <source>Sleep More</source>
+        <translation>Спати довше</translation>
+    </message>
+</context>
+<context>
+    <name>ImportPackagePage</name>
+    <message>
+        <location filename="../qml/pages/ImportPackagePage.qml" line="8"/>
+        <source>Import watchapp or watchface</source>
+        <translation>Імпортувати додаток або циферблат</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ImportPackagePage.qml" line="30"/>
+        <source>Import File?</source>
+        <translation>Справді імпортувати?</translation>
+    </message>
+</context>
+<context>
+    <name>InfoPage</name>
+    <message>
+        <location filename="../qml/pages/InfoPage.qml" line="29"/>
+        <source>Version %1</source>
+        <translation>Версія %1</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InfoPage.qml" line="42"/>
+        <source>Legal</source>
+        <translation>Правова інформація</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InfoPage.qml" line="68"/>
+        <source>This application is neither affiliated with nor endorsed by Pebble Technology Corp.</source>
+        <translation>Цей додаток в жодній мірі не має відношення до Pebble Technology Corp. не будучи ані офіційною ані рекомендованою оболонкою компанії.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InfoPage.qml" line="78"/>
+        <source>Pebble is a trademark of Pebble Technology Corp.</source>
+        <translation>Pebble є регистрованою торгівельною маркою Pebble Technology Corp.</translation>
+    </message>
+</context>
+<context>
+    <name>InstalledAppDelegate</name>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="27"/>
+        <source>Launch</source>
+        <translation>Запустити
+</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="31"/>
+        <source>Settings</source>
+        <translation>Налаштування</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="36"/>
+        <source>Delete</source>
+        <translation>Видалити</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="39"/>
+        <source>Really Delete?</source>
+        <translation>Дійсно Видалити?</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="45"/>
+        <source>Move Up</source>
+        <translation>Посунути Догори</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="50"/>
+        <source>Move Down</source>
+        <translation>Посунути Донизу</translation>
+    </message>
+</context>
+<context>
+    <name>InstalledAppsPage</name>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="18"/>
+        <source>Add New</source>
+        <translation>Добавити</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <source>Apps &amp; Watchfaces</source>
+        <translation>Додатки та Циферблати</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <source>Apps</source>
+        <translation>Додатки</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <source>Watchfaces</source>
+        <translation>Циферблати</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="74"/>
+        <source>Save Apps Order</source>
+        <translation>Зберегти Порядок Додатків</translation>
+    </message>
+</context>
+<context>
+    <name>LoadingPage</name>
+    <message>
+        <location filename="../qml/pages/LoadingPage.qml" line="20"/>
+        <source>Loading and Connecting...</source>
+        <translation>Завантаження та Підключення...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/LoadingPage.qml" line="23"/>
+        <source>Restart Service</source>
+        <translation>Перезапустити Службу</translation>
+    </message>
+</context>
+<context>
+    <name>MainMenuPage</name>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="19"/>
+        <source>About</source>
+        <translation>Про Програму</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="25"/>
+        <source>Developer tools</source>
+        <translation>Інструменти Розробника</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="112"/>
+        <source>Connected</source>
+        <translation>Підключено</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="112"/>
+        <source>Disconnected</source>
+        <translation>Відключено</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="131"/>
+        <source>Upgrading...</source>
+        <translation>Оновлення...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="144"/>
+        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
+        <translation>Ваш годинник Pebble зараз відключен. Будьласка перевірте що він включен, є в досязі та чинно спарений з сістемою Bluetooth.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="154"/>
+        <source>Open System Settings</source>
+        <translation>Відкрити Налаштування Сістеми</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="161"/>
+        <source>Your Pebble smartwatch is in factory mode and needs to be initialized.</source>
+        <translation>Ваш годинник Pebble знаходиться в спеціальному режимі та потребує ініціалізації.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="170"/>
+        <source>Initialize Pebble</source>
+        <translation>Ініціалізувати Pebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="239"/>
+        <source>Manage notifications</source>
+        <translation>Керувати Повідомленнями</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="244"/>
+        <source>Manage Apps</source>
+        <translation>Керувати Додатками</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="250"/>
+        <source>Manage Watchfaces</source>
+        <translation>Керувати Циферблатами</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="256"/>
+        <source>Settings</source>
+        <translation>Налаштування</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="263"/>
+        <source>Manage Firmware</source>
+        <translation>Керувати Прошивкою</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationsPage</name>
+    <message>
+        <location filename="../qml/pages/NotificationsPage.qml" line="15"/>
+        <source>Notifications</source>
+        <translation>Повідомлення</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/NotificationsPage.qml" line="18"/>
+        <source>Entries here will be added as notifications appear on the phone. Selected notifications will be shown on your Pebble smartwatch.</source>
+        <translation>Записи нижче будуть з&apos;являтися згідно з їх появою в телефоні. Вибрані категорії будуть відсилатися до годиннику Pebble.</translation>
+    </message>
+</context>
+<context>
+    <name>PebblesPage</name>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="9"/>
+        <source>RockPool</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="10"/>
+        <source>Manage Pebble Watches</source>
+        <translation>Справа Годинників Pebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="14"/>
+        <source>Settings</source>
+        <translation>Налаштування</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <source>Connected</source>
+        <translation>Підключено</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <source>Disconnected</source>
+        <translation>Відключено</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="55"/>
+        <source>No Pebble smartwatches configured yet. Please connect your Pebble smartwatch using System Settings.</source>
+        <translation>Відсутня жодна конфігурація годинників Pebble. Будьласка підключьте Pebble в Налаштуванні Сістеми.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/PebblesPage.qml" line="64"/>
+        <source>Open System Settings</source>
+        <translation>Відкрити Налаштування Сістеми</translation>
+    </message>
+</context>
+<context>
+    <name>ScreenshotsPage</name>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="20"/>
+        <source>Screenshots</source>
+        <translation>Знімки Екрану</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="24"/>
+        <source>Take Screenshot</source>
+        <translation>Зробити Знімок</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="46"/>
+        <source>Share</source>
+        <translation>Поділитися</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="48"/>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="57"/>
+        <source>Pebble screenshot</source>
+        <translation>Знімок екрану Pebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="55"/>
+        <source>Save</source>
+        <translation>Зберігти</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/ScreenshotsPage.qml" line="64"/>
+        <source>Delete</source>
+        <translation>Видалити</translation>
+    </message>
+</context>
+<context>
+    <name>SettingsPage</name>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="18"/>
+        <source>Settings</source>
+        <translation>Налаштування</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="22"/>
+        <source>Distance Units</source>
+        <translation>Одиниці виміру</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="23"/>
+        <source>Metric</source>
+        <translation>Метричні</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="23"/>
+        <source>Imperial</source>
+        <translation>Імперські</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="39"/>
+        <source>Sync calendar to timeline</source>
+        <translation>Синхронизувати Календар з часовою смугою</translation>
+    </message>
+</context>
+</TS>

--- a/rockwork/translations/rockpool_uk.ts
+++ b/rockwork/translations/rockpool_uk.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="uk" sourcelanguage="en">
+<TS version="2.1" language="uk" sourcelanguage="en">
 <context>
     <name>AppSettingsPage</name>
     <message>
@@ -393,8 +393,8 @@
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="154"/>
-        <source>Open System Settings</source>
-        <translation>Відкрити Налаштування Сістеми</translation>
+        <source>Open Bluetooth Settings</source>
+        <translation>Відкрити Налаштування Bluetooth</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="161"/>
@@ -459,28 +459,28 @@
     </message>
     <message>
         <location filename="../qml/pages/PebblesPage.qml" line="14"/>
-        <source>Settings</source>
-        <translation>Налаштування</translation>
+        <source>Bluetooth Settings</source>
+        <translation>Налаштування Bluetooth</translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <location filename="../qml/pages/PebblesPage.qml" line="37"/>
         <source>Connected</source>
         <translation>Підключено</translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="35"/>
+        <location filename="../qml/pages/PebblesPage.qml" line="37"/>
         <source>Disconnected</source>
         <translation>Відключено</translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="55"/>
+        <location filename="../qml/pages/PebblesPage.qml" line="57"/>
         <source>No Pebble smartwatches configured yet. Please connect your Pebble smartwatch using System Settings.</source>
         <translation>Відсутня жодна конфігурація годинників Pebble. Будьласка підключьте Pebble в Налаштуванні Сістеми.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/PebblesPage.qml" line="64"/>
-        <source>Open System Settings</source>
-        <translation>Відкрити Налаштування Сістеми</translation>
+        <location filename="../qml/pages/PebblesPage.qml" line="66"/>
+        <source>Open Bluetooth Settings</source>
+        <translation>Відкрити Налаштування Bluetooth</translation>
     </message>
 </context>
 <context>
@@ -542,7 +542,7 @@
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="39"/>
         <source>Sync calendar to timeline</source>
-        <translation>Синхронизувати Календар з часовою смугою</translation>
+        <translation>Синхронизувати Календар з Pebble Timeline</translation>
     </message>
 </context>
 </TS>

--- a/rpm/rockpool.spec
+++ b/rpm/rockpool.spec
@@ -92,6 +92,7 @@ update-desktop-database
 %defattr(-,root,root,-)
 %{_bindir}
 %{_datadir}/%{name}/qml
+%{_datadir}/%{name}/translations
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/hicolor/86x86/apps/%{name}.png
 %{_libdir}/systemd/user/%{name}d.service

--- a/rpm/rockpool.yaml
+++ b/rpm/rockpool.yaml
@@ -39,6 +39,7 @@ Requires:
 Files:
 - '%{_bindir}'
 - '%{_datadir}/%{name}/qml'
+- '%{_datadir}/%{name}/translations'
 - '%{_datadir}/applications/%{name}.desktop'
 - '%{_datadir}/icons/hicolor/86x86/apps/%{name}.png'
 - '%{_libdir}/systemd/user/%{name}d.service'


### PR DESCRIPTION
Since with recent commit in mainline i18n has been introduced here I included further integration (app hookup, package info) as well as made two Cyrillic translations to RU and UA languages.
Additionally this merge includes various UI glitches, including icons remapping. It was really noticeable on screenshots (on the phone not that so) that main menu icons were upsclaed and hence blurred. Also in various places were used different icons to represent same meaning. Now it should be more consistent.
Also added (returned) busy indicators for loadable models. They are present in rockwork, while cleaning up I've removed them to speed up process (and see how it works). Now is time to get'm back.

Fixed BT settings launch bug - Issue #15 
Fixed missing signal handler for watchface appsmodel.