### PR TITLE
DevConnection and AppUpgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ You would need to perform following steps:
   * When zypper complains about conflicts - choose option 3 (proceed with broken dependencies)
   * In QtCreator 
 
+* Websockets are used in Pebble for DeveloperConnection and JSKit.WebSockets. Jolla uses Qt5.2 which lacks native websockets support. However there are builds for Qt5.2 and even specifically for jolla already available. To build with websockets support you need to add qt5-qtwebsockets-devel package to the MerSDK from [sfietkonstantin's merproject](http://repo.merproject.org/obs/home:/sfietkonstantin:/sailfish:/latest/sailfishos/) or [coderus' openrepo](https://sailfish.openrepos.net/coderus/personal/main/) repository, for example:
+ * zypper ar -c repo-url websockets
+ * zypper refresh - and confirm downloading unsigned repodata
+
+After that build-time dependency will be automatically resolved by QtCreator/MerSDK during the build. To run that however you'd still need to add it manually on the phone:
+ * ssh to the phone and elevate permissions with devel-su (use System Settings -> Developer Mode for details)
+ * add repository containing qt5-qtwebsockets package used for build (ssu ar http://repo.merproject.org/obs/home:/sfietkonstantin:/sailfish:/latest/sailfishos/ websockets)
+ * refresh the repodata (pkcon refresh) - now you can use Deploy As RPM SDK Run feature to install freshly built RPM with dependencies.
+
 ## The thanks
 
 * Ruslan N. Marchenko - Sailfish UI

--- a/rockwork/applicationsmodel.cpp
+++ b/rockwork/applicationsmodel.cpp
@@ -47,6 +47,12 @@ QVariant ApplicationsModel::data(const QModelIndex &index, int role) const
         return m_apps.at(index.row())->collection();
     case RoleHasCompanion:
         return m_apps.at(index.row())->companion();
+    case RoleChangeLog:
+        return m_apps.at(index.row())->changeLog();
+    case RoleLatest:
+        return m_apps.at(index.row())->latest();
+    case RoleCompatibility:
+        return m_apps.at(index.row())->compatibility();
     }
 
     return QVariant();
@@ -70,6 +76,9 @@ QHash<int, QByteArray> ApplicationsModel::roleNames() const
     roles.insert(RoleGroupId, "groupId");
     roles.insert(RoleCollection, "collection");
     roles.insert(RoleHasCompanion, "companion");
+    roles.insert(RoleChangeLog,"changeLog");
+    roles.insert(RoleLatest,"latest");
+    roles.insert(RoleCompatibility,"compatibility");
     return roles;
 }
 
@@ -400,3 +409,32 @@ QString AppItem::headerImage() const
     return m_headerImage;
 }
 
+QVariantList AppItem::changeLog() const
+{
+    return m_changeLog;
+}
+
+QString AppItem::latest() const
+{
+    return m_latest;
+}
+void AppItem::setLatest(const QString version)
+{
+    m_latest = version;
+    emit latestChanged();
+}
+
+QVariantMap AppItem::compatibility() const
+{
+    return m_compatibility;
+}
+void AppItem::setCompatibility(const QVariantMap &map)
+{
+    m_compatibility = map;
+    emit compatibilityChanged();
+}
+void AppItem::setChangeLog(const QVariantList &log)
+{
+    m_changeLog = log;
+    emit changeLogChanged();
+}

--- a/rockwork/applicationsmodel.h
+++ b/rockwork/applicationsmodel.h
@@ -29,6 +29,9 @@ class AppItem: public QObject
     Q_PROPERTY(QString groupId READ groupId NOTIFY groupIdChanged)
     Q_PROPERTY(QString groupKind READ groupKind NOTIFY groupKindChanged)
 
+    Q_PROPERTY(QVariantList changeLog READ changeLog NOTIFY changeLogChanged)
+    Q_PROPERTY(QString latest READ latest WRITE setLatest NOTIFY latestChanged)
+    Q_PROPERTY(QVariantMap compatibility READ compatibility NOTIFY compatibilityChanged)
 
 public:
     AppItem(QObject *parent = 0);
@@ -79,6 +82,13 @@ public:
     void setGroupId(const QString &groupId, const GroupKind kind = GroupCollection);
     void setGroupKind(const GroupKind kind);
 
+    // For installed app upgrade
+    QVariantList changeLog() const;
+    QVariantMap compatibility() const;
+    QString latest() const;
+    void setLatest(const QString version);
+    void setCompatibility(const QVariantMap &map);
+    void setChangeLog(const QVariantList &log);
 
 signals:
     void versionChanged();
@@ -87,6 +97,9 @@ signals:
     void isWatchFaceChanged();
     void groupIdChanged();
     void groupKindChanged();
+    void changeLogChanged();
+    void latestChanged();
+    void compatibilityChanged();
 
 private:
     QString m_storeId;
@@ -109,6 +122,10 @@ private:
     GroupKind m_groupKind;
 
     QString m_headerImage;
+
+    QVariantList m_changeLog;
+    QString m_latest;
+    QVariantMap m_compatibility;
 };
 
 class ApplicationsModel : public QAbstractListModel
@@ -132,7 +149,10 @@ public:
         RoleCategory,
         RoleGroupId,
         RoleCollection,
-        RoleHasCompanion
+        RoleHasCompanion,
+        RoleChangeLog,
+        RoleLatest,
+        RoleCompatibility
     };
 
     ApplicationsModel(QObject *parent = nullptr);

--- a/rockwork/appstoreclient.h
+++ b/rockwork/appstoreclient.h
@@ -11,7 +11,7 @@ class AppStoreClient : public QObject
 {
     Q_OBJECT
     Q_ENUMS(Type)
-    Q_PROPERTY(ApplicationsModel* model READ model CONSTANT)
+    Q_PROPERTY(ApplicationsModel* model READ model WRITE setModel NOTIFY modelChanged)
     Q_PROPERTY(int limit READ limit WRITE setLimit NOTIFY limitChanged)
     Q_PROPERTY(QString hardwarePlatform READ hardwarePlatform WRITE setHardwarePlatform NOTIFY hardwarePlatformChanged)
     Q_PROPERTY(bool busy READ busy NOTIFY busyChanged)
@@ -26,6 +26,7 @@ public:
     explicit AppStoreClient(QObject *parent = 0);
 
     ApplicationsModel *model() const;
+    void setModel(ApplicationsModel *p_model);
 
     int limit() const;
     void setLimit(int limit);
@@ -43,6 +44,7 @@ signals:
     void hardwarePlatformChanged();
     void busyChanged();
     void enableCategoriesChanged();
+    void modelChanged();
 
 public slots:
     void fetchHome(Type type);
@@ -59,6 +61,7 @@ private:
 private:
     QNetworkAccessManager *m_nam;
     ApplicationsModel *m_model;
+    ApplicationsModel *f_model = 0;
     int m_limit = 20;
     QString m_hardwarePlatform;
     bool m_busy = false;

--- a/rockwork/pebble.cpp
+++ b/rockwork/pebble.cpp
@@ -33,6 +33,8 @@ Pebble::Pebble(const QDBusObjectPath &path, QObject *parent):
     QDBusConnection::sessionBus().connect("org.rockwork", path.path(), "org.rockwork.Pebble", "ProfileWhenConnectedChanged", this, SIGNAL(profileWhenConnectedChanged()));
     QDBusConnection::sessionBus().connect("org.rockwork", path.path(), "org.rockwork.Pebble", "ProfileWhenDisconnectedChanged", this, SIGNAL(profileWhenDisconnectedChanged()));
     QDBusConnection::sessionBus().connect("org.rockwork", path.path(), "org.rockwork.Pebble", "CalendarSyncEnabledChanged", this, SIGNAL(calendarSyncEnabledChanged()));
+    QDBusConnection::sessionBus().connect("org.rockwork", path.path(), "org.rockwork.Pebble", "DevConnectionChanged", this, SLOT(devConStateChanged(bool)));
+    QDBusConnection::sessionBus().connect("org.rockwork", path.path(), "org.rockwork.Pebble", "DevConnCloudChanged", this, SLOT(devConCloudChanged(bool)));
 
     dataChanged();
     refreshApps();
@@ -190,6 +192,55 @@ bool Pebble::calendarSyncEnabled() const
 void Pebble::setCalendarSyncEnabled(bool enabled)
 {
     m_iface->call("SetCalendarSyncEnabled", enabled);
+}
+
+bool Pebble::devConnEnabled() const
+{
+    return fetchProperty("DevConnectionEnabled").toBool();
+}
+void Pebble::setDevConnEnabled(bool enabled)
+{
+    m_iface->call("SetDevConnEnabled", enabled);
+}
+
+bool Pebble::devConnCloudEnabled() const
+{
+    return fetchProperty("DevConnCloudEnabled").toBool();
+}
+void Pebble::setDevConnCloudEnabled(bool enabled)
+{
+    m_iface->call("SetDevConnCloudEnabled",enabled);
+}
+
+quint16 Pebble::devConListenPort() const
+{
+    return (quint16)fetchProperty("DevConnListenPort").toInt();
+}
+void Pebble::setDevConListenPort(quint16 port)
+{
+    m_iface->call("SetDevConnListenPort",port);
+}
+
+bool Pebble::devConnServerRunning() const
+{
+    return fetchProperty("DevConnectionState").toBool();
+}
+
+bool Pebble::devConCloudConnected() const
+{
+    return fetchProperty("DevConnCloudState").toBool();
+}
+
+void Pebble::devConStateChanged(bool state)
+{
+    qDebug() << "DevCon state hase changed:" << (state?"running":"stopped");
+    emit devConnServerRunningChanged();
+}
+
+void Pebble::devConCloudChanged(bool state)
+{
+    qDebug() << "DevConCloud state changed:" << (state?"connected":"disconnected");
+    emit devConCloudConnectedChanged();
 }
 
 void Pebble::configurationClosed(const QString &uuid, const QString &url)

--- a/rockwork/pebble.h
+++ b/rockwork/pebble.h
@@ -30,6 +30,11 @@ class Pebble : public QObject
     Q_PROPERTY(QString profileWhenConnected READ profileWhenConnected WRITE setProfileWhenConnected NOTIFY profileWhenConnectedChanged)
     Q_PROPERTY(QString profileWhenDisconnected READ profileWhenDisconnected WRITE setProfileWhenDisconnected NOTIFY profileWhenDisconnectedChanged)
     Q_PROPERTY(bool calendarSyncEnabled READ calendarSyncEnabled WRITE setCalendarSyncEnabled NOTIFY calendarSyncEnabledChanged)
+    Q_PROPERTY(bool devConnEnabled READ devConnEnabled WRITE setDevConnEnabled NOTIFY devConnEnabledChanged)
+    Q_PROPERTY(bool devConnCloudEnabled READ devConnCloudEnabled WRITE setDevConnCloudEnabled NOTIFY devConnCloudEnabledChanged)
+    Q_PROPERTY(quint16 devConListenPort READ devConListenPort WRITE setDevConListenPort NOTIFY devConListenPortChanged)
+    Q_PROPERTY(bool devConnServerRunning READ devConnServerRunning NOTIFY devConnServerRunningChanged)
+    Q_PROPERTY(bool devConCloudConnected READ devConCloudConnected NOTIFY devConCloudConnectedChanged)
 
 public:
     explicit Pebble(const QDBusObjectPath &path, QObject *parent = 0);
@@ -69,6 +74,12 @@ public:
     bool calendarSyncEnabled() const;
     void setCalendarSyncEnabled(bool enabled);
 
+    bool devConnServerRunning() const;
+    bool devConCloudConnected() const;
+    bool devConnEnabled() const;
+    bool devConnCloudEnabled() const;
+    quint16 devConListenPort() const;
+
 public slots:
     void setNotificationFilter(const QString &sourceId, int enabled);
     void forgetNotificationFilter(const QString &sourceId);
@@ -84,6 +95,10 @@ public slots:
     void performFirmwareUpgrade();
     void dumpLogs(const QString &filename);
 
+    void setDevConnEnabled(bool enabled);
+    void setDevConnCloudEnabled(bool enabled);
+    void setDevConListenPort(quint16 port);
+
 signals:
     void connectedChanged();
     void hardwarePlatformChanged();
@@ -96,6 +111,11 @@ signals:
     void profileWhenDisconnectedChanged();
     void profileWhenConnectedChanged();
     void calendarSyncEnabledChanged();
+    void devConnEnabledChanged();
+    void devConnCloudEnabledChanged();
+    void devConListenPortChanged();
+    void devConnServerRunningChanged();
+    void devConCloudConnectedChanged();
 
     void openURL(const QString &uuid, const QString &url);
 
@@ -114,6 +134,8 @@ private slots:
     void screenshotAdded(const QString &filename);
     void screenshotRemoved(const QString &filename);
     void refreshFirmwareUpdateInfo();
+    void devConStateChanged(bool state);
+    void devConCloudChanged(bool state);
 
 private:
     QDBusObjectPath m_path;

--- a/rockwork/qml/pages/AppUpgradePage.qml
+++ b/rockwork/qml/pages/AppUpgradePage.qml
@@ -1,0 +1,211 @@
+import QtQuick 2.2
+import Sailfish.Silica 1.0
+
+Page {
+    id: root
+
+    property var pebble: null
+    property var app_model: null
+    property int app_index: model.indexOf(app)
+    property var app: app_model.get(app_index)
+
+    SilicaFlickable {
+        anchors.fill: parent
+        contentHeight: contentColumn.height
+        clip: true
+
+        Column {
+            id: contentColumn
+            width: parent.width
+            height: childrenRect.height
+            spacing: Theme.paddingSmall
+
+            PageHeader {
+                title: app ? app.name : qsTr("Upgrading")
+                description: app ? app.vendor : qsTr("Upgrading")
+            }
+
+            Row {
+                width: parent.width
+                height: Theme.iconSizeLarge
+                visible: app != null
+                Image {
+                    source: app ? root.app.icon : ""
+                    height: parent.height
+                    width: height
+                }
+                Separator {
+                    width: Theme.paddingSmall
+                    height: parent.height
+                    color: Theme.secondaryHighlightColor
+                }
+                Row {
+                    width: parent.width - parent.height - Theme.paddingSmall
+                    spacing: Theme.paddingSmall
+                    visible: app != null
+                    Column {
+                        width: parent.width/2
+                        Label {
+                            text: qsTr("Version")
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+                        Label {
+                            text: app ? app.version : ""
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+                    }
+                    Column {
+                        width: parent.width / 2
+                        Label {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: app && app.isWatchFace ? "Watchface" : "Watchapp"
+                        }
+                        Image {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            source: "image://theme/icon-m-" + (app && app.isWatchFace ? "watch" : "toy")
+                            height: Theme.iconSizeSmall
+                            width: height
+                        }
+                    }
+                }
+            }
+            Button {
+                id: installButton
+                width: parent.width
+                enabled: !installing && !root.app.companion
+                property bool installing: false
+                text: enabled ? qsTr("Upgrade") : (installing ? qsTr("Upgrading...") : qsTr("Needs Companion"))
+                Connections {
+                    target: root.pebble.installedApps
+                    onChanged: pageStack.pop()
+                }
+                Connections {
+                    target: root.pebble.installedWatchfaces
+                    onChanged: pageStack.pop()
+                }
+                onClicked: {
+                    root.pebble.installApp(root.app.storeId)
+                    installButton.installing = true
+                }
+            }
+
+            Label {
+                text: qsTr("Compatibility")
+            }
+            Row {
+                width: parent.width
+                visible: root.app != null
+                Column {
+                    width: parent.width / 2
+                    Label {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "Android"
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.bold: true
+                    }
+                    Image {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        source: "image://theme/icon-s-"+(app && app.compatibility.android ? "installed" : "high-importance")
+                    }
+                }
+                Column {
+                    width: parent.width / 2
+                    Label {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "iOS"
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.bold: true
+                    }
+                    Image {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        source: "image://theme/icon-s-"+(app && app.compatibility.ios ? "installed" : "high-importance")
+                    }
+                }
+            }
+            Row {
+                width: parent.width
+                visible: root.app != null
+                Column {
+                    width: parent.width / 3
+                    Label {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "Classic"
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.bold: true
+                    }
+                    Label {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: app ? app.compatibility.aplite : "?"
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.bold: true
+                    }
+                }
+                Column {
+                    width: parent.width / 3
+                    Label {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "Time"
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.bold: true
+                    }
+                    Label {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: app ? app.compatibility.basalt : "?"
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.bold: true
+                    }
+                }
+                Column {
+                    width: parent.width / 3
+                    Label {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: "Time Round"
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.bold: true
+                    }
+                    Label {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        text: app ? app.compatibility.chalk : "?"
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.bold: true
+                    }
+                }
+            }
+            Label {
+                text: qsTr("Change Log")
+            }
+            Repeater {
+                model: root.app ? root.app.changeLog : 0
+                delegate: Column {
+                    width: contentColumn.width
+                    Separator {
+                        width: parent.width
+                        color: Theme.secondaryHighlightColor
+                        height: Theme.paddingSmall
+                    }
+
+                    Row {
+                        width: parent.width
+                        Label {
+                            width: parent.width / 3
+                            text: app.changeLog[index].version
+                            horizontalAlignment: Text.AlignHCenter
+                            font.pixelSize: Theme.fontSizeSmall
+                        }
+                        Label {
+                            width: parent.width / 3
+                            text: app.changeLog[index].published_date
+                            font.pixelSize: Theme.fontSizeSmall
+                        }
+                    }
+                    Label {
+                        width: parent.width
+                        text: app.changeLog[index].release_notes
+                        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                        font.pixelSize: Theme.fontSizeSmall
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rockwork/qml/pages/DeveloperToolsPage.qml
+++ b/rockwork/qml/pages/DeveloperToolsPage.qml
@@ -56,13 +56,13 @@ Page {
         devMenuModel.clear();
 
         devMenuModel.append({
-            icon: "setting",
+            icon: "low-importance",
             text: qsTr("Disable Service"),
             page: "",
             call: "stop"
         });
         devMenuModel.append({
-            icon: "developer",
+            icon: "sync",
             text: qsTr("Restart Service"),
             page: "",
             call: "restart"

--- a/rockwork/qml/pages/DeveloperToolsPage.qml
+++ b/rockwork/qml/pages/DeveloperToolsPage.qml
@@ -39,7 +39,8 @@ Page {
     property var _menu_calls: {
         "stop": function(){rockPool.stopService()},
         "restart": function(){rockPool.restartService()},
-        "logs": function(){sendLogsDocker.show()}
+        "logs": function(){if(devConnDocker.open){devConnDocker.hide()};sendLogsDocker.show()},
+        "dcon": function(){if(sendLogsDocker.open){sendLogsDocker.hide()};devConnDocker.show()}
     }
 
     //Creating the menu list this way to allow the text field to be translatable (http://askubuntu.com/a/476331)
@@ -55,7 +56,7 @@ Page {
         devMenuModel.clear();
 
         devMenuModel.append({
-            icon: "developer",
+            icon: "setting",
             text: qsTr("Disable Service"),
             page: "",
             call: "stop"
@@ -73,6 +74,12 @@ Page {
             call: null
         });
         devMenuModel.append({
+            icon: "developer",
+            text: qsTr("Developer Connection"),
+            page: "",
+            call: "dcon"
+        });
+        devMenuModel.append({
             icon: "task",
             text: qsTr("Report problem"),
             page: "",
@@ -84,6 +91,94 @@ Page {
             page: "ImportPackagePage.qml",
             call: null
         });
+    }
+
+    DockedPanel {
+        id: devConnDocker
+        width: parent.width
+        height: devContent.childrenRect.height
+        dock: Dock.Bottom
+        open: false
+        //z:5
+        Rectangle {
+            anchors.fill: parent
+            color: "black"
+            opacity: 0.66
+        }
+
+        Column {
+            id: devContent
+            width: parent.width
+            SectionHeader {
+                text: qsTr("Developer Connection Settings")
+            }
+
+            IconTextSwitch {
+                width: parent.width
+                text: qsTr("Enable Connection")
+                icon.source: "image://theme/icon-s-high-importance"
+                description: qsTr("Enable Developer Connection Service")
+                onCheckedChanged: root.pebble.devConnEnabled=checked
+                checked: root.pebble.devConnEnabled
+            }
+            Row {
+                width: parent.width
+                TextField {
+                    id: devConPort
+                    property bool changed: false
+                    width: parent.width / 2 - Theme.paddingSmall
+                    label: qsTr("Listen Port")
+                    placeholderText: "9000"
+                    validator: IntValidator {bottom: 1025; top: 65535}
+                    inputMethodHints: Qt.ImhDigitsOnly
+                    onTextChanged: changed = true
+                    color: errorHighlight? "red" : Theme.primaryColor
+                    Component.onCompleted: {
+                        text = root.pebble.devConListenPort
+                        changed = false
+                    }
+                }
+                Button {
+                    width: parent.width / 2 - Theme.paddingSmall
+                    text: qsTr("Apply")
+                    enabled: devConPort.changed && !devConPort.acceptableInput
+                    onClicked: {
+                        root.pebble.devConListenPort=devConPort.text
+                        devConPort.changed = false
+                    }
+                }
+            }
+            IconTextSwitch {
+                width: parent.width
+                text: qsTr("Enable")+" CloudPebble"
+                description: qsTr("Enable DeveloperConnection over CloudPebble")
+                icon.source: "image://theme/icon-s-cloud-upload"
+                checked: root.pebble.devConnCloudEnabled
+                onCheckedChanged: root.pebble.devConnCloudEnabled=checked
+            }
+            SectionHeader {
+                text: qsTr("Runtime Status")
+            }
+            TextSwitch {
+                width: parent.width
+                automaticCheck: false
+                text: qsTr("DeveloperConnection Status")
+                description: qsTr("DeveloperConnection port listening state")
+                checked: root.pebble.devConnServerRunning
+            }
+            TextSwitch {
+                width: parent.width
+                automaticCheck: false
+                text: qsTr("CloudPebble Status")
+                description: qsTr("Indicates CloudPebble connection state")
+                checked: root.pebble.devConCloudConnected
+            }
+            Button {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("Close")
+                onClicked: devConnDocker.hide()
+            }
+        }
     }
 
     DockedPanel {

--- a/rockwork/qml/pages/InstalledAppDelegate.qml
+++ b/rockwork/qml/pages/InstalledAppDelegate.qml
@@ -8,6 +8,8 @@ ListItem {
     property string name: ""
     property string iconSource: ""
     property string vendor: ""
+    property string version: ""
+    property string candidate: ""
     property bool hasSettings: false
     property bool isSystemApp: false
     property bool isLastApp: true
@@ -16,12 +18,20 @@ ListItem {
     signal deleteApp
     signal configureApp
     signal moveApp(int dir)
+    signal upgrade
 
     contentHeight: Theme.itemSizeMedium
     width: parent.width
 
     menu: ContextMenu {
         closeOnActivation: true
+        MenuItem {
+            text: (candidate ? qsTr("Upgrade") + " " + version +  " >> " + candidate : qsTr("Version") + " " + version)
+            onClicked: root.upgrade()
+            enabled: candidate && candidate != version
+            visible: !isSystemApp
+        }
+
         MenuItem {
             text: qsTr("Launch")
             onClicked: root.launchApp()
@@ -75,6 +85,11 @@ ListItem {
                 text: root.vendor
                 font.pixelSize: Theme.fontSizeSmall
             }
+        }
+        Image {
+            source: "image://theme/icon-s-update"
+            visible: candidate && candidate != version
+            anchors.verticalCenter: parent.verticalCenter
         }
     }
     onClicked: showMenu()

--- a/rockwork/qml/pages/MainMenuPage.qml
+++ b/rockwork/qml/pages/MainMenuPage.qml
@@ -152,6 +152,16 @@ Page {
                             anchors.horizontalCenter: parent.horizontalCenter
                             visible: root.pebble.connected && root.pebble.upgradingFirmware
                         }
+                        Image {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            source: "image://theme/icon-s-developer"
+                            visible: root.pebble.devConnServerRunning
+                        }
+                        Label {
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            text: qsTr("Running")
+                            visible: root.pebble.devConnServerRunning
+                        }
                     }
                 }
 

--- a/rockwork/translations/rockpool.ts
+++ b/rockwork/translations/rockpool.ts
@@ -129,6 +129,45 @@
     </message>
 </context>
 <context>
+    <name>AppUpgradePage</name>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="24"/>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="25"/>
+        <source>Upgrading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="49"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Needs Companion</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="93"/>
+        <source>Compatibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="175"/>
+        <source>Change Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ContentPeerPickerPage</name>
     <message>
         <location filename="../qml/pages/ContentPeerPickerPage.qml" line="16"/>
@@ -162,43 +201,113 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="59"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="60"/>
         <source>Disable Service</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="65"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="66"/>
         <source>Restart Service</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="71"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="72"/>
         <source>Screenshots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="77"/>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="99"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="78"/>
+        <source>Developer Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="84"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="194"/>
         <source>Report problem</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="83"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="90"/>
         <source>Install app or watchface from file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="112"/>
-        <source>Preparing logs package...</source>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="113"/>
+        <source>Developer Connection Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="118"/>
+        <source>Enable Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="120"/>
+        <source>Enable Developer Connection Service</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="130"/>
+        <source>Listen Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="143"/>
+        <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/DeveloperToolsPage.qml" line="153"/>
+        <source>Enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="154"/>
+        <source>Enable DeveloperConnection over CloudPebble</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="160"/>
+        <source>Runtime Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="165"/>
+        <source>DeveloperConnection Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="166"/>
+        <source>DeveloperConnection port listening state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="172"/>
+        <source>CloudPebble Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="173"/>
+        <source>Indicates CloudPebble connection state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="178"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="207"/>
+        <source>Preparing logs package...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="248"/>
         <source>Send watch logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="162"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="257"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -363,32 +472,42 @@
 <context>
     <name>InstalledAppDelegate</name>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="26"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Upgrade</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="36"/>
         <source>Launch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="30"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="40"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="35"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="45"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="38"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="48"/>
         <source>Really Delete?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="44"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="54"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="49"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="59"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
@@ -396,27 +515,27 @@
 <context>
     <name>InstalledAppsPage</name>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="18"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="23"/>
         <source>Add New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps &amp; Watchfaces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Watchfaces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="73"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="86"/>
         <source>Save Apps Order</source>
         <translation type="unfinished"></translation>
     </message>
@@ -468,46 +587,51 @@
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="162"/>
-        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
+        <source>Running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="172"/>
+        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="182"/>
         <source>Open Bluetooth Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="179"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="189"/>
         <source>Your Pebble smartwatch is in factory mode and needs to be initialized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="188"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="198"/>
         <source>Initialize Pebble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="257"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="267"/>
         <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="262"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="272"/>
         <source>Watch Apps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="268"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="278"/>
         <source>Watchfaces</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="274"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="284"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="281"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="291"/>
         <source>Firmware</source>
         <translation type="unfinished"></translation>
     </message>

--- a/rockwork/translations/rockpool_de.ts
+++ b/rockwork/translations/rockpool_de.ts
@@ -129,6 +129,45 @@
     </message>
 </context>
 <context>
+    <name>AppUpgradePage</name>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="24"/>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="25"/>
+        <source>Upgrading</source>
+        <translation>Aktualisieren</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="49"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrade</source>
+        <translation>Aktualisierung</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrading...</source>
+        <translation>Aktualisieren...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Needs Companion</source>
+        <translation>Companion benötigt</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="93"/>
+        <source>Compatibility</source>
+        <translation>Kompatibilität</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="175"/>
+        <source>Change Log</source>
+        <translation>Änderungsprotokoll</translation>
+    </message>
+</context>
+<context>
     <name>ContentPeerPickerPage</name>
     <message>
         <location filename="../qml/pages/ContentPeerPickerPage.qml" line="16"/>
@@ -162,43 +201,113 @@
         <translation>Entwicklerwerkzeuge</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="59"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="60"/>
         <source>Disable Service</source>
         <translation>Dienst deaktivieren</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="65"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="66"/>
         <source>Restart Service</source>
-        <translation type="unfinished">Dienst neu starten</translation>
+        <translation>Dienst neu starten</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="71"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="72"/>
         <source>Screenshots</source>
         <translation>Screenshots</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="77"/>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="99"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="78"/>
+        <source>Developer Connection</source>
+        <translation>Entwickleranschluss</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="84"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="194"/>
         <source>Report problem</source>
         <translation>Problem melden</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="83"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="90"/>
         <source>Install app or watchface from file</source>
         <translation>Installieren App oder Zifferblatt aus Datei</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="112"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="113"/>
+        <source>Developer Connection Settings</source>
+        <translation>Entwickleranschluss Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="118"/>
+        <source>Enable Connection</source>
+        <translation>Anschluss aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="120"/>
+        <source>Enable Developer Connection Service</source>
+        <translation>Entwickleranschluss Dienst Aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="130"/>
+        <source>Listen Port</source>
+        <translation>Port mithören</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="143"/>
+        <source>Apply</source>
+        <translation>Übernehmen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="153"/>
+        <source>Enable</source>
+        <translation>Anlassen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="154"/>
+        <source>Enable DeveloperConnection over CloudPebble</source>
+        <translation>Entwickleranschluss um die CloudPebble anlassen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="160"/>
+        <source>Runtime Status</source>
+        <translation>Aktueller Zustand</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="165"/>
+        <source>DeveloperConnection Status</source>
+        <translation>Stand des Entwickleranschlusses</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="166"/>
+        <source>DeveloperConnection port listening state</source>
+        <translation>Zeigt ob Entwikleranschluss lokaler Port mithört</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="172"/>
+        <source>CloudPebble Status</source>
+        <translation>Zustand der CloudPebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="173"/>
+        <source>Indicates CloudPebble connection state</source>
+        <translation>Zeigt ob Entwikleranschluss mit der CloudPebble verbunden ist</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="178"/>
+        <source>Close</source>
+        <translation>Schließen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="207"/>
         <source>Preparing logs package...</source>
         <translation>Logbuch vorbereiten...</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="153"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="248"/>
         <source>Send watch logs</source>
         <translation>Senden Uhr Protokolle</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="162"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="257"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -363,32 +472,42 @@
 <context>
     <name>InstalledAppDelegate</name>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="26"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Upgrade</source>
+        <translation>Aktualisierung</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="36"/>
         <source>Launch</source>
         <translation>Starten</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="30"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="40"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="35"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="45"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="38"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="48"/>
         <source>Really Delete?</source>
         <translation>Wirklich löschen?</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="44"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="54"/>
         <source>Move Up</source>
         <translation>Nach oben verschieben</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="49"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="59"/>
         <source>Move Down</source>
         <translation>Nach unten verschieben</translation>
     </message>
@@ -396,27 +515,27 @@
 <context>
     <name>InstalledAppsPage</name>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="18"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="23"/>
         <source>Add New</source>
         <translation>Neue hinzufügen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps &amp; Watchfaces</source>
         <translation>Apps &amp; Zifferblätter</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps</source>
         <translation>Anwendungen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Watchfaces</source>
         <translation>Zifferblätter</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="73"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="86"/>
         <source>Save Apps Order</source>
         <translation>App-Reihenfolge speichern</translation>
     </message>
@@ -439,77 +558,82 @@
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="19"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>Über</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="25"/>
         <source>Developer tools</source>
-        <translation type="unfinished"></translation>
+        <translation>Entwicklerwerkzeuge</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="120"/>
         <source>Connected</source>
-        <translation type="unfinished">Verbunden</translation>
+        <translation>Verbunden</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="120"/>
         <source>Disconnected</source>
-        <translation type="unfinished">Getrennt</translation>
+        <translation>Getrennt</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="128"/>
         <source>Update Available</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktualisierung verfügbar</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="150"/>
         <source>Upgrading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktualisieren...</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="162"/>
-        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
-        <translation type="unfinished"></translation>
+        <source>Running</source>
+        <translation>Laufend</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="172"/>
+        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
+        <translation>Ihre Pebble Smartwatch ist nicht verbunden. Bitte stellen Sie sicher, dass es eingeschaltet ist, in Reichweite, und in den Bluetooth-Systemeinstellungen richtig gepaart ist.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="182"/>
         <source>Open Bluetooth Settings</source>
-        <translation type="unfinished">Bluetooth-Einstellungen öffnen</translation>
+        <translation>Bluetooth-Einstellungen öffnen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="179"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="189"/>
         <source>Your Pebble smartwatch is in factory mode and needs to be initialized.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ihre Pebble Smartwatch ist im Werksmodus und muss initialisiert werden.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="188"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="198"/>
         <source>Initialize Pebble</source>
-        <translation type="unfinished"></translation>
+        <translation>Pebble initialisieren</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="257"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="267"/>
         <source>Notifications</source>
-        <translation type="unfinished">Benachrichtigungen</translation>
+        <translation>Benachrichtigungen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="262"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="272"/>
         <source>Watch Apps</source>
-        <translation type="unfinished"></translation>
+        <translation>Anwendungen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="268"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="278"/>
         <source>Watchfaces</source>
-        <translation type="unfinished">Zifferblätter</translation>
+        <translation>Zifferblätter</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="274"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="284"/>
         <source>Settings</source>
-        <translation type="unfinished">Einstellungen</translation>
+        <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="281"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="291"/>
         <source>Firmware</source>
-        <translation type="unfinished"></translation>
+        <translation>Firmware</translation>
     </message>
 </context>
 <context>
@@ -532,17 +656,17 @@
     <message>
         <location filename="../qml/pages/NotificationsPage.qml" line="69"/>
         <source>Disabled When Active</source>
-        <translation type="unfinished"></translation>
+        <translation>Deaktiviert wenn aktiv</translation>
     </message>
     <message>
         <location filename="../qml/pages/NotificationsPage.qml" line="75"/>
         <source>Always Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation>Immer deaktiviert</translation>
     </message>
     <message>
         <location filename="../qml/pages/NotificationsPage.qml" line="81"/>
         <source>Forget</source>
-        <translation type="unfinished"></translation>
+        <translation>Verlernen</translation>
     </message>
 </context>
 <context>
@@ -656,7 +780,7 @@
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="48"/>
         <source>Automatic Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Automatisches Profil</translation>
     </message>
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="56"/>
@@ -669,7 +793,7 @@
         <location filename="../qml/pages/SettingsPage.qml" line="79"/>
         <location filename="../qml/pages/SettingsPage.qml" line="89"/>
         <source>no change</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine Änderung</translation>
     </message>
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="76"/>

--- a/rockwork/translations/rockpool_fr.ts
+++ b/rockwork/translations/rockpool_fr.ts
@@ -129,6 +129,45 @@
     </message>
 </context>
 <context>
+    <name>AppUpgradePage</name>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="24"/>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="25"/>
+        <source>Upgrading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="49"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrade</source>
+        <translation>Mise à jour</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrading...</source>
+        <translation>Mise à jour...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Needs Companion</source>
+        <translation>Nécéssite un Companion</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="93"/>
+        <source>Compatibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="175"/>
+        <source>Change Log</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ContentPeerPickerPage</name>
     <message>
         <location filename="../qml/pages/ContentPeerPickerPage.qml" line="16"/>
@@ -162,43 +201,113 @@
         <translation>Outils de développement</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="59"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="60"/>
         <source>Disable Service</source>
         <translation>Désactiver le service</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="65"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="66"/>
         <source>Restart Service</source>
         <translation type="unfinished">Redémarrer le Service</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="71"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="72"/>
         <source>Screenshots</source>
         <translation>Captures d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="77"/>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="99"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="78"/>
+        <source>Developer Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="84"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="194"/>
         <source>Report problem</source>
         <translation>Rapporter un problème</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="83"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="90"/>
         <source>Install app or watchface from file</source>
         <translation>Installer une application ou une watchface depuis un fichier</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="112"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="113"/>
+        <source>Developer Connection Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="118"/>
+        <source>Enable Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="120"/>
+        <source>Enable Developer Connection Service</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="130"/>
+        <source>Listen Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="143"/>
+        <source>Apply</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="153"/>
+        <source>Enable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="154"/>
+        <source>Enable DeveloperConnection over CloudPebble</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="160"/>
+        <source>Runtime Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="165"/>
+        <source>DeveloperConnection Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="166"/>
+        <source>DeveloperConnection port listening state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="172"/>
+        <source>CloudPebble Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="173"/>
+        <source>Indicates CloudPebble connection state</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="178"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="207"/>
         <source>Preparing logs package...</source>
         <translation>Préparation du package de journaux...</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="153"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="248"/>
         <source>Send watch logs</source>
         <translation>Envoyer les journaux de la montre</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="162"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="257"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -363,32 +472,42 @@
 <context>
     <name>InstalledAppDelegate</name>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="26"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Upgrade</source>
+        <translation>Mise à jour</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="36"/>
         <source>Launch</source>
         <translation>Lancer</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="30"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="40"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="35"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="45"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="38"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="48"/>
         <source>Really Delete?</source>
         <translation>Confirmer suppression</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="44"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="54"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="49"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="59"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
@@ -396,27 +515,27 @@
 <context>
     <name>InstalledAppsPage</name>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="18"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="23"/>
         <source>Add New</source>
         <translation>Ajouter</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps &amp; Watchfaces</source>
         <translation>Applications &amp; Watchfaces</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps</source>
         <translation>Applications</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Watchfaces</source>
         <translation>Watchfaces</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="73"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="86"/>
         <source>Save Apps Order</source>
         <translation>Enregistrer l&apos;ordre des applications</translation>
     </message>
@@ -449,7 +568,7 @@
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="120"/>
         <source>Connected</source>
-        <translation type="unfinished">Connecté</translation>
+        <translation>Connecté</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="120"/>
@@ -464,50 +583,55 @@
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="150"/>
         <source>Upgrading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Mise à jour...</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="162"/>
-        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
+        <source>Running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="172"/>
-        <source>Open Bluetooth Settings</source>
-        <translation type="unfinished">Ouvrir les paramètres Bluetooth</translation>
+        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="179"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="182"/>
+        <source>Open Bluetooth Settings</source>
+        <translation>Ouvrir les paramètres Bluetooth</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="189"/>
         <source>Your Pebble smartwatch is in factory mode and needs to be initialized.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="188"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="198"/>
         <source>Initialize Pebble</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="257"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="267"/>
         <source>Notifications</source>
-        <translation type="unfinished">Notifications</translation>
+        <translation>Notifications</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="262"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="272"/>
         <source>Watch Apps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="268"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="278"/>
         <source>Watchfaces</source>
-        <translation type="unfinished">Watchfaces</translation>
+        <translation>Watchfaces</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="274"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="284"/>
         <source>Settings</source>
-        <translation type="unfinished">Paramètres</translation>
+        <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="281"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="291"/>
         <source>Firmware</source>
         <translation type="unfinished"></translation>
     </message>

--- a/rockwork/translations/rockpool_ru.ts
+++ b/rockwork/translations/rockpool_ru.ts
@@ -131,6 +131,45 @@
     </message>
 </context>
 <context>
+    <name>AppUpgradePage</name>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="24"/>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="25"/>
+        <source>Upgrading</source>
+        <translation>Обновляется</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="49"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrade</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrading...</source>
+        <translation>Обновление...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Needs Companion</source>
+        <translation>Нужен Компаньон</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="93"/>
+        <source>Compatibility</source>
+        <translation>Совместимость</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="175"/>
+        <source>Change Log</source>
+        <translation>История Изменений</translation>
+    </message>
+</context>
+<context>
     <name>ContentPeerPickerPage</name>
     <message>
         <location filename="../qml/pages/ContentPeerPickerPage.qml" line="16"/>
@@ -164,43 +203,113 @@
         <translation>Инструменты Разработчика</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="59"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="60"/>
         <source>Disable Service</source>
         <translation>Выключить Сервис</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="65"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="66"/>
         <source>Restart Service</source>
-        <translation type="unfinished">Перезапустить Сервис</translation>
+        <translation>Перезапустить Сервис</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="71"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="72"/>
         <source>Screenshots</source>
         <translation>Снимки Экрана</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="77"/>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="99"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="78"/>
+        <source>Developer Connection</source>
+        <translation>Подключение Разработчика</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="84"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="194"/>
         <source>Report problem</source>
         <translation>Сообщить о Проблеме</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="83"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="90"/>
         <source>Install app or watchface from file</source>
         <translation>Установить приложение из файла</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="112"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="113"/>
+        <source>Developer Connection Settings</source>
+        <translation>Настройки Подключения Разработчика</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="118"/>
+        <source>Enable Connection</source>
+        <translation>Активировать подключение</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="120"/>
+        <source>Enable Developer Connection Service</source>
+        <translation>Активировать Сервис Подключения Разработчика</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="130"/>
+        <source>Listen Port</source>
+        <translation>Слушать Порт</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="143"/>
+        <source>Apply</source>
+        <translation>Применить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="153"/>
+        <source>Enable</source>
+        <translation>Включить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="154"/>
+        <source>Enable DeveloperConnection over CloudPebble</source>
+        <translation>Включить Подключение Разработчика через CloudPebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="160"/>
+        <source>Runtime Status</source>
+        <translation>Текущее Состояние</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="165"/>
+        <source>DeveloperConnection Status</source>
+        <translation>Состояние Подключения</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="166"/>
+        <source>DeveloperConnection port listening state</source>
+        <translation>Слушает ли служба подключения локальный порт</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="172"/>
+        <source>CloudPebble Status</source>
+        <translation>Состояние CloudPebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="173"/>
+        <source>Indicates CloudPebble connection state</source>
+        <translation>Подключена ли служба подключений к сервису CloudPebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="178"/>
+        <source>Close</source>
+        <translation>Закрыть</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="207"/>
         <source>Preparing logs package...</source>
         <translation>Подготовка пакета журналов...</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="153"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="248"/>
         <source>Send watch logs</source>
         <translation>Послать журнал с часов</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="162"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="257"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
@@ -365,32 +474,42 @@
 <context>
     <name>InstalledAppDelegate</name>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="26"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Upgrade</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="36"/>
         <source>Launch</source>
         <translation>Запустить</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="30"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="40"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="35"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="45"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="38"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="48"/>
         <source>Really Delete?</source>
         <translation>Действительно Удалить?</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="44"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="54"/>
         <source>Move Up</source>
         <translation>Подвинуть Вверх</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="49"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="59"/>
         <source>Move Down</source>
         <translation>Подвинуть Вниз</translation>
     </message>
@@ -398,27 +517,27 @@
 <context>
     <name>InstalledAppsPage</name>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="18"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="23"/>
         <source>Add New</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps &amp; Watchfaces</source>
         <translation>Приложения и Циферблаты</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps</source>
         <translation>Приложения</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Watchfaces</source>
         <translation>Циферблаты</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="73"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="86"/>
         <source>Save Apps Order</source>
         <translation>Сохранить Порядок Пакетов</translation>
     </message>
@@ -441,77 +560,82 @@
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="19"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>О Программе</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="25"/>
         <source>Developer tools</source>
-        <translation type="unfinished"></translation>
+        <translation>Инструменты Разработчика</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="120"/>
         <source>Connected</source>
-        <translation type="unfinished"></translation>
+        <translation>Подключено</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="120"/>
         <source>Disconnected</source>
-        <translation type="unfinished"></translation>
+        <translation>Отключено</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="128"/>
         <source>Update Available</source>
-        <translation type="unfinished"></translation>
+        <translation>Есть Обновление</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="150"/>
         <source>Upgrading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Обновление...</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="162"/>
-        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
-        <translation type="unfinished"></translation>
+        <source>Running</source>
+        <translation>Активно</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="172"/>
+        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
+        <translation>Ваши часы Pebble в данный момент отключены. Пожалуйста убедитесь что они включены, находятся в пределах досягаемости и добавлены в системных настройках Bluetooth.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="182"/>
         <source>Open Bluetooth Settings</source>
-        <translation type="unfinished">Открыть Настройки Bluetooth</translation>
+        <translation>Открыть Настройки Bluetooth</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="179"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="189"/>
         <source>Your Pebble smartwatch is in factory mode and needs to be initialized.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ваши часы Pebble находятся в специальном режиме и требуют инициализации.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="188"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="198"/>
         <source>Initialize Pebble</source>
-        <translation type="unfinished"></translation>
+        <translation>Инициализировать Pebble</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="257"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="267"/>
         <source>Notifications</source>
-        <translation type="unfinished">Уведомления</translation>
+        <translation>Уведомления</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="262"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="272"/>
         <source>Watch Apps</source>
-        <translation type="unfinished"></translation>
+        <translation>Приложения</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="268"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="278"/>
         <source>Watchfaces</source>
-        <translation type="unfinished">Циферблаты</translation>
+        <translation>Циферблаты</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="274"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="284"/>
         <source>Settings</source>
-        <translation type="unfinished">Настройки</translation>
+        <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="281"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="291"/>
         <source>Firmware</source>
-        <translation type="unfinished"></translation>
+        <translation>Прошивка</translation>
     </message>
 </context>
 <context>
@@ -544,7 +668,7 @@
     <message>
         <location filename="../qml/pages/NotificationsPage.qml" line="81"/>
         <source>Forget</source>
-        <translation type="unfinished"></translation>
+        <translation>Забыть</translation>
     </message>
 </context>
 <context>
@@ -658,7 +782,7 @@
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="48"/>
         <source>Automatic Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоматический Профиль</translation>
     </message>
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="56"/>
@@ -671,7 +795,7 @@
         <location filename="../qml/pages/SettingsPage.qml" line="79"/>
         <location filename="../qml/pages/SettingsPage.qml" line="89"/>
         <source>no change</source>
-        <translation type="unfinished"></translation>
+        <translation>без изменений</translation>
     </message>
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="76"/>

--- a/rockwork/translations/rockpool_uk.ts
+++ b/rockwork/translations/rockpool_uk.ts
@@ -129,6 +129,45 @@
     </message>
 </context>
 <context>
+    <name>AppUpgradePage</name>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="24"/>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="25"/>
+        <source>Upgrading</source>
+        <translation>Оновлення</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="49"/>
+        <source>Version</source>
+        <translation>Версія</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrade</source>
+        <translation>Обновити</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Upgrading...</source>
+        <translation>Оновлення...</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="77"/>
+        <source>Needs Companion</source>
+        <translation>Потрібен Компаньйон</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="93"/>
+        <source>Compatibility</source>
+        <translation>Cумісність</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AppUpgradePage.qml" line="175"/>
+        <source>Change Log</source>
+        <translation>Історія Змін</translation>
+    </message>
+</context>
+<context>
     <name>ContentPeerPickerPage</name>
     <message>
         <location filename="../qml/pages/ContentPeerPickerPage.qml" line="16"/>
@@ -162,43 +201,113 @@
         <translation>Інструменти Розробника</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="59"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="60"/>
         <source>Disable Service</source>
         <translation>Відключити Сервіс</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="65"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="66"/>
         <source>Restart Service</source>
-        <translation type="unfinished">Перезапустити Службу</translation>
+        <translation>Перезапустити Службу</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="71"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="72"/>
         <source>Screenshots</source>
         <translation>Знімки Екрану</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="77"/>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="99"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="78"/>
+        <source>Developer Connection</source>
+        <translation>Підключення Розробника</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="84"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="194"/>
         <source>Report problem</source>
         <translation>Повідомити про Проблему</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="83"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="90"/>
         <source>Install app or watchface from file</source>
         <translation>Встановити додаток з файлу</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="112"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="113"/>
+        <source>Developer Connection Settings</source>
+        <translation>Налаштування Підключення Розробника</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="118"/>
+        <source>Enable Connection</source>
+        <translation>Активувати Підключення</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="120"/>
+        <source>Enable Developer Connection Service</source>
+        <translation>Активувати сервіс Підключення Розробника</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="130"/>
+        <source>Listen Port</source>
+        <translation>Слухати Порт</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="143"/>
+        <source>Apply</source>
+        <translation>Прийняти</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="153"/>
+        <source>Enable</source>
+        <translation>Ввімкнути</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="154"/>
+        <source>Enable DeveloperConnection over CloudPebble</source>
+        <translation>Активує Підключення Розробника через CloudPebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="160"/>
+        <source>Runtime Status</source>
+        <translation>Поточний статус</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="165"/>
+        <source>DeveloperConnection Status</source>
+        <translation>Стан Підключення Розробника</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="166"/>
+        <source>DeveloperConnection port listening state</source>
+        <translation>Вказує чи слухає Підключення Розробника локальний порт</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="172"/>
+        <source>CloudPebble Status</source>
+        <translation>Стан CloudPebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="173"/>
+        <source>Indicates CloudPebble connection state</source>
+        <translation>Вказує чи підключена зараз служба до CloudPebble</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="178"/>
+        <source>Close</source>
+        <translation>Закрити</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="207"/>
         <source>Preparing logs package...</source>
         <translation>Підготовка пакету журналів...</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="153"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="248"/>
         <source>Send watch logs</source>
         <translation>Відіслати журнал з годинника</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="162"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="257"/>
         <source>Cancel</source>
         <translation>Відмінити</translation>
     </message>
@@ -363,33 +472,43 @@
 <context>
     <name>InstalledAppDelegate</name>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="26"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Upgrade</source>
+        <translation>Обновити</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="29"/>
+        <source>Version</source>
+        <translation>Версія</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="36"/>
         <source>Launch</source>
         <translation>Запустити
 </translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="30"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="40"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="35"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="45"/>
         <source>Delete</source>
         <translation>Видалити</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="38"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="48"/>
         <source>Really Delete?</source>
         <translation>Дійсно Видалити?</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="44"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="54"/>
         <source>Move Up</source>
         <translation>Посунути Догори</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppDelegate.qml" line="49"/>
+        <location filename="../qml/pages/InstalledAppDelegate.qml" line="59"/>
         <source>Move Down</source>
         <translation>Посунути Донизу</translation>
     </message>
@@ -397,27 +516,27 @@
 <context>
     <name>InstalledAppsPage</name>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="18"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="23"/>
         <source>Add New</source>
         <translation>Добавити</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps &amp; Watchfaces</source>
         <translation>Додатки та Циферблати</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Apps</source>
         <translation>Додатки</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="27"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="32"/>
         <source>Watchfaces</source>
         <translation>Циферблати</translation>
     </message>
     <message>
-        <location filename="../qml/pages/InstalledAppsPage.qml" line="73"/>
+        <location filename="../qml/pages/InstalledAppsPage.qml" line="86"/>
         <source>Save Apps Order</source>
         <translation>Зберегти Порядок Додатків</translation>
     </message>
@@ -440,77 +559,82 @@
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="19"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>Про Програму</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="25"/>
         <source>Developer tools</source>
-        <translation type="unfinished"></translation>
+        <translation>Інструменти Розробника</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="120"/>
         <source>Connected</source>
-        <translation type="unfinished">Підключено</translation>
+        <translation>Підключено</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="120"/>
         <source>Disconnected</source>
-        <translation type="unfinished">Відключено</translation>
+        <translation>Відключено</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="128"/>
         <source>Update Available</source>
-        <translation type="unfinished"></translation>
+        <translation>Нова Прошивка</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="150"/>
         <source>Upgrading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Оновлення...</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="162"/>
-        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
-        <translation type="unfinished"></translation>
+        <source>Running</source>
+        <translation>Активно</translation>
     </message>
     <message>
         <location filename="../qml/pages/MainMenuPage.qml" line="172"/>
+        <source>Your Pebble smartwatch is disconnected. Please make sure it is powered on, within range and it is paired properly in the Bluetooth System Settings.</source>
+        <translation>Ваш годинник Pebble зараз відключен. Будьласка перевірте що він включен, є в досязі та чинно спарений з сістемою Bluetooth.</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainMenuPage.qml" line="182"/>
         <source>Open Bluetooth Settings</source>
-        <translation type="unfinished">Відкрити Налаштування Bluetooth</translation>
+        <translation>Відкрити Налаштування Bluetooth</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="179"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="189"/>
         <source>Your Pebble smartwatch is in factory mode and needs to be initialized.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ваш годинник Pebble знаходиться в спеціальному режимі та потребує ініціалізації.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="188"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="198"/>
         <source>Initialize Pebble</source>
-        <translation type="unfinished"></translation>
+        <translation>Ініціалізувати Pebble</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="257"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="267"/>
         <source>Notifications</source>
-        <translation type="unfinished">Повідомлення</translation>
+        <translation>Повідомлення</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="262"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="272"/>
         <source>Watch Apps</source>
-        <translation type="unfinished"></translation>
+        <translation>Додатки</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="268"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="278"/>
         <source>Watchfaces</source>
-        <translation type="unfinished">Циферблати</translation>
+        <translation>Циферблати</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="274"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="284"/>
         <source>Settings</source>
-        <translation type="unfinished">Налаштування</translation>
+        <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../qml/pages/MainMenuPage.qml" line="281"/>
+        <location filename="../qml/pages/MainMenuPage.qml" line="291"/>
         <source>Firmware</source>
-        <translation type="unfinished"></translation>
+        <translation>Прошивка</translation>
     </message>
 </context>
 <context>
@@ -543,7 +667,7 @@
     <message>
         <location filename="../qml/pages/NotificationsPage.qml" line="81"/>
         <source>Forget</source>
-        <translation type="unfinished"></translation>
+        <translation>Забути</translation>
     </message>
 </context>
 <context>
@@ -657,7 +781,7 @@
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="48"/>
         <source>Automatic Profile</source>
-        <translation type="unfinished"></translation>
+        <translation>Автоматичний Профіль</translation>
     </message>
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="56"/>
@@ -670,7 +794,7 @@
         <location filename="../qml/pages/SettingsPage.qml" line="79"/>
         <location filename="../qml/pages/SettingsPage.qml" line="89"/>
         <source>no change</source>
-        <translation type="unfinished"></translation>
+        <translation>без змін</translation>
     </message>
     <message>
         <location filename="../qml/pages/SettingsPage.qml" line="76"/>

--- a/rockworkd/dbusinterface.cpp
+++ b/rockworkd/dbusinterface.cpp
@@ -20,6 +20,8 @@ DBusPebble::DBusPebble(Pebble *pebble, QObject *parent):
     connect(pebble, &Pebble::imperialUnitsChanged, this, &DBusPebble::ImperialUnitsChanged);
     connect(pebble, &Pebble::profileConnectionSwitchChanged, this, &DBusPebble::onProfileConnectionSwitchChanged);
     connect(pebble, &Pebble::calendarSyncEnabledChanged, this, &DBusPebble::CalendarSyncEnabledChanged);
+    connect(pebble, &Pebble::devConServerStateChanged, this, &DBusPebble::DevConnectionChanged);
+    connect(pebble, &Pebble::devConCloudStateChanged, this, &DBusPebble::DevConnCloudChanged);
 }
 
 QString DBusPebble::Address() const
@@ -70,6 +72,46 @@ void DBusPebble::SetNotificationFilter(const QString &sourceId, int enabled)
 void DBusPebble::ForgetNotificationFilter(const QString &sourceId)
 {
     m_pebble->forgetNotificationFilter(sourceId);
+}
+
+bool DBusPebble::DevConnectionEnabled() const
+{
+    return m_pebble->devConEnabled();
+}
+
+quint16 DBusPebble::DevConnListenPort() const
+{
+    return m_pebble->devConListenPort();
+}
+
+bool DBusPebble::DevConnCloudEnabled() const
+{
+    return m_pebble->devConCloudEnabled();
+}
+
+void DBusPebble::SetDevConnEnabled(bool enabled)
+{
+    m_pebble->setDevConEnabled(enabled);
+}
+
+void DBusPebble::SetDevConnListenPort(quint16 port)
+{
+    m_pebble->setDevConListenPort(port);
+}
+
+void DBusPebble::SetDevConnCloudEnabled(bool enabled)
+{
+    m_pebble->setDevConCloudEnabled(enabled);
+}
+
+bool DBusPebble::DevConnectionState() const
+{
+    return m_pebble->devConServerState();
+}
+
+bool DBusPebble::DevConnCloudState() const
+{
+    return m_pebble->devConCloudState();
 }
 
 void DBusPebble::InstallApp(const QString &id)

--- a/rockworkd/dbusinterface.h
+++ b/rockworkd/dbusinterface.h
@@ -32,6 +32,9 @@ signals:
     void ProfileWhenDisconnectedChanged();
     void CalendarSyncEnabledChanged();
 
+    void DevConnectionChanged(const bool state);
+    void DevConnCloudChanged(const bool state);
+
 public slots:
     QString Address() const;
     QString Name() const;
@@ -50,6 +53,15 @@ public slots:
     QVariantMap NotificationsFilter() const;
     void SetNotificationFilter(const QString &sourceId, int enabled);
     void ForgetNotificationFilter(const QString &sourceId);
+
+    bool DevConnectionEnabled() const;
+    quint16 DevConnListenPort() const;
+    bool DevConnectionState() const;
+    bool DevConnCloudEnabled() const;
+    bool DevConnCloudState() const;
+    void SetDevConnEnabled(bool enabled);
+    void SetDevConnCloudEnabled(bool enabled);
+    void SetDevConnListenPort(quint16 port);
 
     void InstallApp(const QString &id);
     void SideloadApp(const QString &packageFile);

--- a/rockworkd/libpebble/appdownloader.cpp
+++ b/rockworkd/libpebble/appdownloader.cpp
@@ -52,8 +52,8 @@ void AppDownloader::appJsonFetched()
         return;
     }
 
-    QString appid = reply->property("storeId").toString();
-    QUuid quuid = QUuid(appMap.value("uuid").toUuid());
+    QString appid = appMap.value("id").toString();
+    QUuid quuid = appMap.value("uuid").toUuid();
     QDir dir;
     Pebble *p = (Pebble *)parent();
     if(p->installedAppIds().contains(quuid)) {

--- a/rockworkd/libpebble/appdownloader.cpp
+++ b/rockworkd/libpebble/appdownloader.cpp
@@ -1,7 +1,5 @@
 #include "appdownloader.h"
-#include "watchconnection.h"
-#include "watchdatareader.h"
-#include "watchdatawriter.h"
+#include "pebble.h"
 #include "ziphelper.h"
 
 #include <QNetworkAccessManager>
@@ -22,7 +20,6 @@ void AppDownloader::downloadApp(const QString &id)
 {
     QNetworkRequest request(QUrl("https://api2.getpebble.com/v2/apps/id/" + id));
     QNetworkReply *reply = m_nam->get(request);
-    reply->setProperty("storeId", id);
     connect(reply, &QNetworkReply::finished, this, &AppDownloader::appJsonFetched);
 }
 
@@ -30,8 +27,6 @@ void AppDownloader::appJsonFetched()
 {
     QNetworkReply *reply = static_cast<QNetworkReply*>(sender());
     reply->deleteLater();
-
-    QString storeId = reply->property("storeId").toString();
 
     if (reply->error() != QNetworkReply::NoError) {
         qWarning() << "Error fetching App Json" << reply->errorString();
@@ -57,16 +52,29 @@ void AppDownloader::appJsonFetched()
         return;
     }
 
+    QString appid = reply->property("storeId").toString();
+    QUuid quuid = QUuid(appMap.value("uuid").toUuid());
     QDir dir;
-    dir.mkpath(m_storagePath + storeId);
+    Pebble *p = (Pebble *)parent();
+    if(p->installedAppIds().contains(quuid)) {
+        AppInfo ai = p->appInfo(quuid);
+        QString exId = ai.storeId();
+        if(appid != exId && !dir.exists(m_storagePath+appid) && dir.exists(m_storagePath+exId)) {
+            dir.rename(m_storagePath+exId,m_storagePath+appid);
+        } else if(appid != exId) {
+            qWarning() << "App exists but dir is out of sync:" << exId << "<!>" << appid;
+        }
+    } else {
+        dir.mkpath(m_storagePath + appid);
+    }
 
     QString iconFile = appMap.value("list_image").toMap().value("144x144").toString();
     QNetworkRequest request(iconFile);
     QNetworkReply *imageReply = m_nam->get(request);
     qDebug() << "fetching image" << iconFile;
-    connect(imageReply, &QNetworkReply::finished, [this, imageReply, storeId]() {
+    connect(imageReply, &QNetworkReply::finished, [this, imageReply, appid]() {
         imageReply->deleteLater();
-        QString targetFile = m_storagePath + storeId + "/list_image.png";
+        QString targetFile = m_storagePath + appid + "/list_image.png";
         qDebug() << "saving image to" << targetFile;
         QFile f(targetFile);
         if (f.open(QFile::WriteOnly)) {
@@ -74,15 +82,16 @@ void AppDownloader::appJsonFetched()
             f.close();
         }
     });
-
-    fetchPackage(pbwFileUrl, storeId);
+    appid += ("/v" + appMap.value("latest_release").toMap().value("version").toString() + ".pbw");
+    fetchPackage(pbwFileUrl, appid);
 }
 
-void AppDownloader::fetchPackage(const QString &url, const QString &storeId)
+void AppDownloader::fetchPackage(const QString &url, const QString &file)
 {
     QNetworkRequest request(url);
     QNetworkReply *reply = m_nam->get(request);
-    reply->setProperty("storeId", storeId);
+    qDebug() << "Fetching app to" << file;
+    reply->setProperty("file", file);
     connect(reply, &QNetworkReply::finished, this, &AppDownloader::packageFetched);
 }
 
@@ -91,9 +100,9 @@ void AppDownloader::packageFetched()
     QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
     reply->deleteLater();
 
-    QString storeId = reply->property("storeId").toString();
+    QString file = reply->property("file").toString();
 
-    QFile f(m_storagePath + storeId + "/" + reply->request().url().fileName() + ".zip");
+    QFile f(m_storagePath + file);
     if (!f.open(QFile::WriteOnly | QFile::Truncate)) {
         qWarning() << "Error opening file for writing";
         return;
@@ -102,12 +111,12 @@ void AppDownloader::packageFetched()
     f.flush();
     f.close();
 
-    QString zipName = m_storagePath + storeId + "/" + reply->request().url().fileName() + ".zip";
+    QString appid = file.split("/").first();
 
-    if (!ZipHelper::unpackArchive(zipName, m_storagePath + storeId)) {
+    if (!ZipHelper::unpackArchive(m_storagePath+file, m_storagePath + appid)) {
         qWarning() << "Error unpacking App zip file";
         return;
     }
 
-    emit downloadFinished(storeId);
+    emit downloadFinished(appid);
 }

--- a/rockworkd/libpebble/appmanager.cpp
+++ b/rockworkd/libpebble/appmanager.cpp
@@ -165,7 +165,8 @@ void AppManager::sortingReply(const QByteArray &data)
 
 void AppManager::insertAppInfo(const AppInfo &info)
 {
-    m_appList.append(info.uuid());
+    if(!m_appList.contains(info.uuid()))
+        m_appList.append(info.uuid());
     m_apps.insert(info.uuid(), info);
 //    m_appsIds.insert(info.id(), info.uuid());
     emit appsChanged();

--- a/rockworkd/libpebble/blobdb.cpp
+++ b/rockworkd/libpebble/blobdb.cpp
@@ -335,7 +335,7 @@ void BlobDB::clearApps()
     s.remove("");
 }
 
-void BlobDB::insertAppMetaData(const AppInfo &info)
+void BlobDB::insertAppMetaData(const AppInfo &info,const bool force)
 {
     if (!m_pebble->connected()) {
         qWarning() << "Pebble is not connected. Cannot install app";
@@ -343,7 +343,7 @@ void BlobDB::insertAppMetaData(const AppInfo &info)
     }
 
     QSettings s(m_blobDBStoragePath + "/appsyncstate.conf", QSettings::IniFormat);
-    if (s.value(info.uuid().toString(), false).toBool()) {
+    if (s.value(info.uuid().toString(), false).toBool() && !force) {
         qWarning() << "App already in DB. Not syncing again";
         return;
     }

--- a/rockworkd/libpebble/blobdb.h
+++ b/rockworkd/libpebble/blobdb.h
@@ -45,7 +45,7 @@ public:
     void syncCalendar(const QList<CalendarEvent> &events);
 
     void clearApps();
-    void insertAppMetaData(const AppInfo &info);
+    void insertAppMetaData(const AppInfo &info, const bool force=false);
     void removeApp(const AppInfo &info);
 
     void insert(BlobDBId database, const TimelineItem &item);

--- a/rockworkd/libpebble/devconnection.cpp
+++ b/rockworkd/libpebble/devconnection.cpp
@@ -1,0 +1,254 @@
+#include "devconnection.h"
+
+#include "pebble.h"
+#include "watchconnection.h"
+
+#include <QException>
+#include <QWebSocketServer>
+#include <QWebSocket>
+
+#include <QDebug>
+
+DevConnection::DevConnection(Pebble *pebble, WatchConnection *connection):
+    QObject(pebble),
+    m_pebble(pebble),
+    m_connection(connection),
+    m_qtwsServer(0)
+{
+    QObject::connect(pebble, &Pebble::devConEnabledChanged, this, &DevConnection::onEnableChanged);
+    QObject::connect(pebble, &Pebble::devConListenPortChanged, this, &DevConnection::onPortChanged);
+    QObject::connect(pebble, &Pebble::devConCloudEnabledChanged, this, &DevConnection::onCloudEnableChanged);
+    QObject::connect(connection, &WatchConnection::watchConnected, this, &DevConnection::onWatchConnected);
+    QObject::connect(connection, &WatchConnection::watchDisconnected, this, &DevConnection::onWatchDisconnected);
+    QObject::connect(connection, &WatchConnection::rawIncomingMsg, this, &DevConnection::onRawIncomingMsg);
+    QObject::connect(connection, &WatchConnection::rawOutgoingMsg, this, &DevConnection::onRawOutgoingMsg);
+}
+DevConnection::~DevConnection()
+{
+    disableConnection();
+}
+
+bool DevConnection::enabled() const
+{
+    return m_qtwsServer!=nullptr;
+}
+quint16 DevConnection::listenPort() const
+{
+    return m_port;
+}
+bool DevConnection::cloudEnabled() const
+{
+    return false; // TODO
+}
+// pebble slots
+void DevConnection::onEnableChanged(bool enabled)
+{
+    if(enabled && m_qtwsServer==nullptr) {
+        enableConnection(m_port);
+    } else if(!enabled && m_qtwsServer) {
+        disableConnection();
+    }
+}
+void DevConnection::onPortChanged(quint16 port) {
+    if(port != m_port && port > 0 && m_qtwsServer) {
+        if(m_qtwsServer->isListening())
+            disableConnection();
+        enableConnection(port);
+    } else {
+        m_port = port;
+    }
+}
+void DevConnection::onCloudEnableChanged(bool enabled)
+{
+    Q_UNUSED(enabled); // no idea how it works
+    // Pebble-tool connects to wss://cloudpebble-ws-proxy-prod.herokuapp.com/tool
+    // But what does phone do - need to capture with mitm (:TODO:)
+}
+void DevConnection::onWatchConnected()
+{
+    qDebug() << "Watch connected, need to resume DevCon in progress: " << m_clients.length();
+}
+void DevConnection::onWatchDisconnected()
+{
+    qDebug() << "Watch disconnected, need to pause DevCon in progress: " << m_clients.length();
+}
+void DevConnection::onRawIncomingMsg(const QByteArray &msg)
+{
+    QByteArray data=QByteArray(msg);
+    data.prepend(char(0));
+    broadcast(data);
+    qDebug() << "Broadcast inMsg: " << data.toHex();
+}
+void DevConnection::onRawOutgoingMsg(const QByteArray &msg)
+{
+    QByteArray data=QByteArray(msg);
+    data.prepend(char(1));
+    broadcast(data);
+    qDebug() << "Broadcast outMsg: " << data.toHex();
+}
+void DevConnection::onAppLogMsg(const QByteArray &msg)
+{
+    QByteArray data=QByteArray(QString(msg).toUtf8());
+    data.prepend(char(2));
+    broadcast(data);
+    qDebug() << "Broadcast appLog: " << data.toHex();
+}
+
+// other api slots
+void DevConnection::disableConnection()
+{
+    if(m_qtwsServer) {
+        delete m_qtwsServer;
+        m_qtwsServer = nullptr;
+    }
+    if(m_clients.length()>0) {
+        QWebSocket *sock;
+        foreach (sock, m_clients) {
+            sock->close();
+            delete sock;
+        }
+        m_clients.clear();
+    }
+}
+void DevConnection::enableConnection(quint16 port)
+{
+    if(m_qtwsServer==nullptr) {
+        m_qtwsServer=new QWebSocketServer("Jolla",QWebSocketServer::SslMode::NonSecureMode,this);
+        QObject::connect(m_qtwsServer, &QWebSocketServer::newConnection, this, &DevConnection::socketConnected);
+    }
+    if(port>0) {
+        m_port=port;
+        if(m_qtwsServer->isListening())
+            m_qtwsServer->close();
+        if(m_qtwsServer->listen(QHostAddress::Any,m_port)) {
+            qDebug() << "DevConnection listening on *:" << m_port;
+        } else {
+            qWarning() << "Error listening on " << port << ": " << m_qtwsServer->errorString();
+            delete m_qtwsServer;
+            m_qtwsServer = nullptr;
+        }
+    }
+}
+void DevConnection::sendToWatch(const QByteArray &msg)
+{
+    m_connection->writeRawData(msg);
+}
+
+// private slots/handlers
+void DevConnection::socketConnected()
+{
+    QWebSocket *sock = m_qtwsServer->nextPendingConnection();
+    m_clients.append(sock);
+    qDebug() << "Accepted new connection from " << sock->peerAddress().toString();
+    QObject::connect(sock,&QWebSocket::textMessageReceived,this,&DevConnection::textDataReceived);
+    QObject::connect(sock,&QWebSocket::binaryMessageReceived,this,&DevConnection::rawDataReceived);
+    QObject::connect(sock,&QWebSocket::disconnected,this,&DevConnection::socketDisconnected);
+}
+void DevConnection::socketDisconnected()
+{
+     QWebSocket *sock = qobject_cast<QWebSocket *>(sender());
+     qDebug() << "Client disconnected: " << sock->peerAddress().toString();
+     m_clients.removeAll(sock);
+     delete sock;
+}
+void DevConnection::textDataReceived(QString msg)
+{
+    // We aren't supposed to receive sms are we? remove this sun-over-bij
+     QWebSocket *sock = qobject_cast<QWebSocket *>(sender());
+     sock->close();
+     m_clients.removeAll(sock);
+     delete sock;
+     // what did he say anyway?
+     qWarning() << "Unexpected Text Message received while waiting for ByteArray:" << msg;
+}
+void DevConnection::rawDataReceived(QByteArray data)
+{
+     QWebSocket *sock = qobject_cast<QWebSocket *>(sender());
+     try {
+        DevPacket *pkt = DevPacket::CreatePacket(data,sock,this);
+        pkt->execute();
+        if(!pkt->isValid()) {
+            delete pkt;
+        } else {
+            QObject::connect(pkt,&DevPacket::complete,[pkt](){delete pkt;});
+        }
+     } catch(QException &e) {
+         qWarning() << "DevPacket not understood: " << data;
+     }
+}
+void DevConnection::broadcast(const QByteArray &msg)
+{
+    if(m_clients.length()>0) {
+        QWebSocket *sock;
+        foreach (sock, m_clients) {
+            if(sock->sendBinaryMessage(msg)!=msg.size()) {
+                qWarning() << "Failure while sending to " << sock->peerAddress().toString();
+                sock->close();
+                m_clients.removeAll(sock);
+                delete sock;
+            }
+        }
+    }
+}
+
+// DevPacket implementation (and definition)
+DevPacket::DevPacket(QByteArray &data, QWebSocket *sock, DevConnection *srv):
+    QObject(srv),
+    m_data(data),
+    m_sock(nullptr),
+    m_srv(srv)
+{
+    QObject::connect(sock,&QWebSocket::disconnected,this,&DevPacket::complete);
+    //QObject::connect(sock,&QWebSocket::destroyed,this,&DevPacket::complete);
+}
+void DevPacket::serverDown()
+{
+    emit complete();
+}
+
+class DevPacketRelay:public DevPacket
+{
+public:
+    DevPacketRelay(QByteArray &data, QWebSocket *sock, DevConnection *srv):
+        DevPacket(data,sock,srv)
+    {
+        m_sock=sock;
+    }
+
+    bool isRequest() const { return true;}
+    bool isReply() const { return true;}
+    void execute() {
+        qDebug() << "Relay this (" << m_data.toHex() << ") to pebble";
+        m_srv->sendToWatch(m_data.right(m_data.size()-1));
+    }
+};
+class DevPacketPInfo:public DevPacket
+{
+public:
+    DevPacketPInfo(QByteArray &data, QWebSocket *sock, DevConnection *srv):
+        DevPacket(data,sock,srv)
+    {
+        m_sock=sock;
+        m_data.replace(1,m_data.size(),"rocpoold,1.0.0,pebble");
+    }
+
+    bool isRequest() const {return true;}
+    bool isReply() const {return true;}
+    void execute() {m_sock->sendBinaryMessage(m_data);m_sock=nullptr;}
+};
+
+DevPacket * DevPacket::CreatePacket(QByteArray &data, QWebSocket *sock, DevConnection *srv)
+{
+    char opcode = data.at(0);
+    switch (opcode) {
+    case OCPhoneServerInfo:
+        return new DevPacketPInfo(data,sock,srv);
+        break;
+    case OCRelayToWatch:
+        return new DevPacketRelay(data,sock,srv);
+        break;
+    default:
+        throw QException();
+    }
+    return nullptr;
+}

--- a/rockworkd/libpebble/devconnection.h
+++ b/rockworkd/libpebble/devconnection.h
@@ -1,0 +1,92 @@
+#ifndef DEVCONNECTION_H
+#define DEVCONNECTION_H
+
+#include <QObject>
+
+QT_FORWARD_DECLARE_CLASS(QWebSocketServer)
+QT_FORWARD_DECLARE_CLASS(QWebSocket)
+QT_FORWARD_DECLARE_CLASS(DevPacket)
+QT_FORWARD_DECLARE_CLASS(Pebble)
+QT_FORWARD_DECLARE_CLASS(WatchConnection)
+
+class DevConnection : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DevConnection(Pebble *pebble, WatchConnection *connection);
+    virtual ~DevConnection();
+
+    bool enabled() const;
+    bool cloudEnabled() const;
+    quint16 listenPort() const;
+
+signals:
+    void devConnected();
+    void serverDown();
+
+public slots:
+    void enableConnection(quint16 port);
+    void disableConnection();
+    void onEnableChanged(bool enabled);
+    void onPortChanged(quint16 port);
+    void onCloudEnableChanged(bool enabled);
+    void onWatchConnected();
+    void sendToWatch(const QByteArray &msg);
+    void onWatchDisconnected();
+    void onRawIncomingMsg(const QByteArray &msg);
+    void onRawOutgoingMsg(const QByteArray &msg);
+    void onAppLogMsg(const QByteArray &msg);
+private slots:
+    void socketConnected();
+    void socketDisconnected();
+    void textDataReceived(QString msg);
+    void rawDataReceived(QByteArray data);
+    void broadcast(const QByteArray &msg);
+private:
+    QList<QWebSocket *> m_clients;
+    Pebble *m_pebble;
+    WatchConnection *m_connection;
+    QWebSocketServer *m_qtwsServer;
+    quint16 m_port = 0;
+};
+
+class DevPacket : public QObject
+{
+    Q_OBJECT
+public:
+    enum OpCode {
+        OCRelayFromWatch,       // 0
+        OCRelayToWatch,         // 1 bytes
+        OCPhoneAppLog,          // 2
+        OCPhoneServerLog,       // 3
+        OCInstallBundle,        // 4 bytes
+        OCInstallStatus,        // 5 {uint32(1),uint32(0)}
+        OCPhoneServerInfo,      // 6 strz
+        OCConStatusUpdate,      // 7
+        OCProxyStatusUpdate,    // 8 {0,ff}
+        OCProxyAuthResponse,    // 9 {0,1}
+        OCPhoneConfigResponse,  // a
+        OCRelayEmulator,        // b
+        OCTimelineOperation     // c
+    };
+
+    bool isValid() {return m_sock != nullptr;}
+    virtual bool isRequest() const = 0;
+    virtual bool isReply() const = 0;
+    virtual void execute() = 0;
+    static DevPacket * CreatePacket(QByteArray &data, QWebSocket *sock, DevConnection *srv);
+    virtual ~DevPacket() = default;
+signals:
+    void complete();
+
+private slots:
+    void serverDown();
+
+protected:
+    DevPacket(QByteArray &data, QWebSocket *sock, DevConnection *srv);
+    QByteArray &m_data;
+    QWebSocket *m_sock;
+    DevConnection *m_srv;
+};
+
+#endif // DEVCONNECTION_H

--- a/rockworkd/libpebble/devconnection.h
+++ b/rockworkd/libpebble/devconnection.h
@@ -32,6 +32,7 @@ public slots:
     void onCloudEnableChanged(bool enabled);
     void onWatchConnected();
     void sendToWatch(const QByteArray &msg);
+    void installBundle(QString file);
     void onWatchDisconnected();
     void onRawIncomingMsg(const QByteArray &msg);
     void onRawOutgoingMsg(const QByteArray &msg);

--- a/rockworkd/libpebble/devconnection.h
+++ b/rockworkd/libpebble/devconnection.h
@@ -73,7 +73,7 @@ public:
         OCProxyAuthResponse,    // 9 {0,1}
         OCPhoneConfigResponse,  // a
         OCRelayEmulator,        // b
-        OCTimelineOperation     // c
+        OCTimelineOperation     // c {char(0x1|0x2),json}
     };
 
     bool isValid() {return m_sock != nullptr;}

--- a/rockworkd/libpebble/devconnection.h
+++ b/rockworkd/libpebble/devconnection.h
@@ -20,16 +20,21 @@ public:
     bool cloudEnabled() const;
     quint16 listenPort() const;
 
+    bool serverState() const;
+    bool cloudState() const;
+
 signals:
-    void devConnected();
-    void serverDown();
+    void serverStateChanged(bool state);
+    void cloudStateChanged(bool state);
 
 public slots:
     void enableConnection(quint16 port);
     void disableConnection();
-    void onEnableChanged(bool enabled);
-    void onPortChanged(quint16 port);
-    void onCloudEnableChanged(bool enabled);
+
+    void setEnabled(bool enabled);
+    void setPort(quint16 port);
+    void setCloudEnabled(bool enabled);
+
     void onWatchConnected();
     void sendToWatch(const QByteArray &msg);
     void installBundle(QString file);

--- a/rockworkd/libpebble/devconnection.h
+++ b/rockworkd/libpebble/devconnection.h
@@ -41,7 +41,6 @@ public slots:
     void onWatchDisconnected();
     void onRawIncomingMsg(const QByteArray &msg);
     void onRawOutgoingMsg(const QByteArray &msg);
-    void onAppLogMsg(const QByteArray &msg);
 private slots:
     void socketConnected();
     void socketDisconnected();
@@ -54,6 +53,10 @@ private:
     WatchConnection *m_connection;
     QWebSocketServer *m_qtwsServer;
     quint16 m_port = 0;
+    // kinda singleton
+    static DevConnection *s_instance;
+    static void appLogBroadcast(QtMsgType t, const QMessageLogContext &ctx, const QString &msg);
+    static QtMessageHandler s_omh;
 };
 
 class DevPacket : public QObject
@@ -61,19 +64,19 @@ class DevPacket : public QObject
     Q_OBJECT
 public:
     enum OpCode {
-        OCRelayFromWatch,       // 0
-        OCRelayToWatch,         // 1 bytes
-        OCPhoneAppLog,          // 2
-        OCPhoneServerLog,       // 3
-        OCInstallBundle,        // 4 bytes
-        OCInstallStatus,        // 5 {uint32(1),uint32(0)}
-        OCPhoneServerInfo,      // 6 strz
+        OCRelayFromWatch,       // 0 <-bytes
+        OCRelayToWatch,         // 1 ->bytes
+        OCPhoneAppLog,          // 2 <-
+        OCPhoneServerLog,       // 3 <-
+        OCInstallBundle,        // 4 ->bytes
+        OCInstallStatus,        // 5 <-{uint32(1),uint32(0)}
+        OCPhoneServerInfo,      // 6 <-strz
         OCConStatusUpdate,      // 7
         OCProxyStatusUpdate,    // 8 {0,ff}
         OCProxyAuthResponse,    // 9 {0,1}
         OCPhoneConfigResponse,  // a
         OCRelayEmulator,        // b
-        OCTimelineOperation     // c {char(0x1|0x2),json}
+        OCTimelineOperation     // c <>{char(0x0|0x1|0x2),"json"}
     };
 
     bool isValid() {return m_sock != nullptr;}

--- a/rockworkd/libpebble/pebble.cpp
+++ b/rockworkd/libpebble/pebble.cpp
@@ -123,10 +123,14 @@ Pebble::Pebble(const QBluetoothAddress &address, QObject *parent):
     QObject::connect(this, &Pebble::profileConnectionSwitchChanged, this, &Pebble::profileSwitchRequired);
 
     m_devConnection = new DevConnection(this, m_connection);
+    QObject::connect(m_devConnection, &DevConnection::serverStateChanged, this, &Pebble::devConServerStateChanged);
+    QObject::connect(m_devConnection, &DevConnection::cloudStateChanged, this, &Pebble::devConCloudStateChanged);
     settings.beginGroup("devConnection");
-    m_devConnection->onEnableChanged(settings.value("enabled", true).toBool()); // TODO set to false, testing only
-    m_devConnection->onPortChanged(settings.value("listenPort", 9000).toInt());
-    m_devConnection->onCloudEnableChanged(settings.value("useCloud", true).toBool()); // not implemented yet
+    // DeveloperConnection is a backdoor to the pebble, it has no authentication whatsoever.
+    // Dont ever enable it automatically, only on-demand by explicit user request!!111
+    //m_devConnection->setEnabled(settings.value("enabled", true).toBool());
+    m_devConnection->setPort(settings.value("listenPort", 9000).toInt());
+    m_devConnection->setCloudEnabled(settings.value("useCloud", true).toBool()); // not implemented yet
     settings.endGroup();
 
 }
@@ -261,7 +265,7 @@ bool Pebble::devConEnabled() const
 }
 void Pebble::setDevConEnabled(bool enabled)
 {
-    m_devConnection->onEnableChanged(enabled);
+    m_devConnection->setEnabled(enabled);
 }
 quint16 Pebble::devConListenPort() const
 {
@@ -269,7 +273,11 @@ quint16 Pebble::devConListenPort() const
 }
 void Pebble::setDevConListenPort(quint16 port)
 {
-    m_devConnection->onPortChanged(port);
+    m_devConnection->setPort(port);
+}
+bool Pebble::devConServerState() const
+{
+    return m_devConnection->serverState();
 }
 bool Pebble::devConCloudEnabled() const
 {
@@ -277,7 +285,11 @@ bool Pebble::devConCloudEnabled() const
 }
 void Pebble::setDevConCloudEnabled(bool enabled)
 {
-    m_devConnection->onCloudEnableChanged(enabled);
+    m_devConnection->setCloudEnabled(enabled);
+}
+bool Pebble::devConCloudState() const
+{
+    return m_devConnection->cloudState();
 }
 
 void Pebble::setHealthParams(const HealthParams &healthParams)

--- a/rockworkd/libpebble/pebble.cpp
+++ b/rockworkd/libpebble/pebble.cpp
@@ -17,6 +17,7 @@
 #include "platforminterface.h"
 #include "ziphelper.h"
 #include "dataloggingendpoint.h"
+#include "devconnection.h"
 
 #include "QDir"
 #include <QDateTime>
@@ -119,6 +120,14 @@ Pebble::Pebble(const QBluetoothAddress &address, QObject *parent):
     QObject::connect(m_connection, &WatchConnection::watchConnected, this, &Pebble::profileSwitchRequired);
     QObject::connect(m_connection, &WatchConnection::watchDisconnected, this, &Pebble::profileSwitchRequired);
     QObject::connect(this, &Pebble::profileConnectionSwitchChanged, this, &Pebble::profileSwitchRequired);
+
+    m_devConnection = new DevConnection(this, m_connection);
+    settings.beginGroup("devConnection");
+    m_devConnection->onEnableChanged(settings.value("enabled", true).toBool()); // TODO set to false, testing only
+    m_devConnection->onPortChanged(settings.value("listenPort", 9000).toInt());
+    m_devConnection->onCloudEnableChanged(settings.value("useCloud", true).toBool()); // not implemented yet
+    settings.endGroup();
+
 }
 
 QBluetoothAddress Pebble::address() const
@@ -243,6 +252,31 @@ bool Pebble::recovery() const
 bool Pebble::upgradingFirmware() const
 {
     return m_firmwareDownloader->upgrading();
+}
+
+bool Pebble::devConEnabled() const
+{
+    return m_devConnection->enabled();
+}
+void Pebble::setDevConEnabled(bool enabled)
+{
+    m_devConnection->onEnableChanged(enabled);
+}
+quint16 Pebble::devConListenPort() const
+{
+    return m_devConnection->listenPort();
+}
+void Pebble::setDevConListenPort(quint16 port)
+{
+    m_devConnection->onPortChanged(port);
+}
+bool Pebble::devConCloudEnabled() const
+{
+    return m_devConnection->cloudEnabled();
+}
+void Pebble::setDevConCloudEnabled(bool enabled)
+{
+    m_devConnection->onCloudEnableChanged(enabled);
 }
 
 void Pebble::setHealthParams(const HealthParams &healthParams)

--- a/rockworkd/libpebble/pebble.h
+++ b/rockworkd/libpebble/pebble.h
@@ -76,7 +76,9 @@ public:
     };
     bool devConEnabled() const;
     quint16 devConListenPort() const;
+    bool devConServerState() const;
     bool devConCloudEnabled() const;
+    bool devConCloudState() const;
 public slots:
     QVariantMap notificationsFilter() const;
     void setNotificationFilter(const QString &sourceId, const QString &name, const QString &icon, const NotificationFilter enabled);
@@ -164,9 +166,8 @@ signals:
     void imperialUnitsChanged();
     void profileConnectionSwitchChanged(bool connected);
     void healtParamsChanged();
-    void devConEnabledChanged(bool enabled);
-    void devConListenPortChanged(quint16 port);
-    void devConCloudEnabledChanged(bool enabled);
+    void devConServerStateChanged(bool state);
+    void devConCloudStateChanged(bool state);
 private:
     void setHardwareRevision(HardwareRevision hardwareRevision);
 

--- a/rockworkd/libpebble/pebble.h
+++ b/rockworkd/libpebble/pebble.h
@@ -26,6 +26,7 @@ class ScreenshotEndpoint;
 class FirmwareDownloader;
 class WatchLogEndpoint;
 class DataLoggingEndpoint;
+class DevConnection;
 
 class Pebble : public QObject
 {
@@ -73,6 +74,9 @@ public:
         NotificationDisabledActive = 1,
         NotificationEnabled = 2
     };
+    bool devConEnabled() const;
+    quint16 devConListenPort() const;
+    bool devConCloudEnabled() const;
 public slots:
     QVariantMap notificationsFilter() const;
     void setNotificationFilter(const QString &sourceId, const QString &name, const QString &icon, const NotificationFilter enabled);
@@ -81,6 +85,10 @@ public slots:
     QString findNotificationData(const QString &sourceId, const QString &key);
     void sendSimpleNotification(const QUuid &uuid, const QString &title, const QString &body);
     void sendNotification(const Notification &notification);
+
+    void setDevConEnabled(bool enabled);
+    void setDevConListenPort(quint16 port);
+    void setDevConCloudEnabled(bool enabled);
 
     void clearTimeline();
     void setCalendarSyncEnabled(bool enabled);
@@ -156,6 +164,9 @@ signals:
     void imperialUnitsChanged();
     void profileConnectionSwitchChanged(bool connected);
     void healtParamsChanged();
+    void devConEnabledChanged(bool enabled);
+    void devConListenPortChanged(quint16 port);
+    void devConCloudEnabledChanged(bool enabled);
 private:
     void setHardwareRevision(HardwareRevision hardwareRevision);
 
@@ -198,6 +209,7 @@ private:
     QString m_profileWhenDisconnected = "ignore";
     HealthParams m_healthParams;
     bool m_imperialUnits = false;
+    DevConnection *m_devConnection;
 };
 
 /*

--- a/rockworkd/libpebble/watchconnection.cpp
+++ b/rockworkd/libpebble/watchconnection.cpp
@@ -111,7 +111,12 @@ void WatchConnection::writeToPebble(Endpoint endpoint, const QByteArray &data)
     msg.append(endpoint & 0xFF);
 
     msg.append(data);
+    writeRawData(msg);
+    emit rawOutgoingMsg(msg);
+}
 
+void WatchConnection::writeRawData(const QByteArray &msg)
+{
     //qDebug() << "Writing:" << msg.toHex();
     m_socket->write(msg);
 }
@@ -187,6 +192,7 @@ void WatchConnection::readyRead()
 
     QByteArray data = m_socket->read(headerLength + messageLength);
 //    qDebug() << "Have message for endpoint:" << endpoint << "data:" << data.toHex();
+    emit rawIncomingMsg(data);
 
     data = data.right(data.length() - 4);
 

--- a/rockworkd/libpebble/watchconnection.h
+++ b/rockworkd/libpebble/watchconnection.h
@@ -117,6 +117,7 @@ public:
     QByteArray buildData(QStringList data);
     QByteArray buildMessageData(uint lead, QStringList data);
 
+    void writeRawData(const QByteArray &data);
     void writeToPebble(Endpoint endpoint, const QByteArray &data);
     void systemMessage(SystemMessage msg);
 
@@ -126,6 +127,9 @@ signals:
     void watchConnected();
     void watchDisconnected();
     void watchConnectionFailed();
+
+    void rawOutgoingMsg(QByteArray &msg);
+    void rawIncomingMsg(QByteArray &msg);
 
 private:
     void scheduleReconnect();

--- a/rockworkd/rockworkd.pro
+++ b/rockworkd/rockworkd.pro
@@ -12,7 +12,7 @@ CONFIG += link_pkgconfig
 INCLUDEPATH += $$[QT_HOST_PREFIX]/include/quazip/
 LIBS += -lquazip
 
-PKGCONFIG += qt5-boostable libmkcal-qt5 libkcalcoren-qt5 dbus-1 mpris-qt5 timed-qt5
+PKGCONFIG += qt5-boostable libmkcal-qt5 libkcalcoren-qt5 dbus-1 mpris-qt5 timed-qt5 Qt5WebSockets
 INCLUDEPATH += /usr/include/mkcal-qt5 /usr/include/kcalcoren-qt5
 
 SOURCES += main.cpp \
@@ -20,6 +20,7 @@ SOURCES += main.cpp \
     libpebble/pebble.cpp \
     libpebble/watchdatareader.cpp \
     libpebble/watchdatawriter.cpp \
+    libpebble/devconnection.cpp \
     libpebble/notificationendpoint.cpp \
     libpebble/musicendpoint.cpp \
     libpebble/phonecallendpoint.cpp \
@@ -75,6 +76,7 @@ HEADERS += \
     libpebble/pebble.h \
     libpebble/watchdatareader.h \
     libpebble/watchdatawriter.h \
+    libpebble/devconnection.h \
     libpebble/notificationendpoint.h \
     libpebble/musicendpoint.h \
     libpebble/musicmetadata.h \

--- a/rockworkd/rockworkd.pro
+++ b/rockworkd/rockworkd.pro
@@ -1,4 +1,4 @@
-QT += core bluetooth dbus network contacts qml location websockets
+QT += core bluetooth dbus network contacts qml location
 QT -= gui
 
 include(../version.pri)

--- a/rpm/rockpool.yaml
+++ b/rpm/rockpool.yaml
@@ -23,6 +23,7 @@ PkgConfigBR:
 - Qt5Network
 - Qt5Location
 - qt5-boostable
+- Qt5WebSockets
 - mpris-qt5
 - timed-qt5
 - mlite5


### PR DESCRIPTION
Two major things - as per subj - Added classes and pages for new elements.

Changes in the core (daemon): 
* Apps sideloaded to uuid instead of sideloadX (old dirs preserved for installed apps)
* Apps could be re-installed (allows upgrade) with new "force" option to insertAppMetadata
* Added raw*Message signals allowing eavesdropping watch communication (req. for DevCon)

Changes in the core (client):
* Added ability to override model in the storeclient - to allow installedApps to use appstoreclient
* Extended fetchAppDetails call to fetch details from appstore needed for App Upgrade.
* Extended app model with version/changelog/compat attributes.