### PR TITLE
Built-in apps implementation: Weather and Sent Text

### DIFF
--- a/rockworkd/dbusinterface.cpp
+++ b/rockworkd/dbusinterface.cpp
@@ -87,14 +87,45 @@ QVariantMap DBusPebble::cannedResponses() const
 /**
  * @brief DBusPebble::setCannedResponses
  * @param cans aass
- * Example call:
- * gdbus call -e -d org.rockwork -o /org/rockwork/XX_XX_XX_XX_XX_XX
- *  -m org.rockwork.Pebble.setCannedResponses
- *  "{'x-nemo.messaging.im': <@as ['Aye','Nay','On my way']>;, 'x-nemo.messaging.sms': <@as ['Ok']>}"</pre>
+ * @example gdbus call -e -d org.rockwork -o /org/rockwork/XX_XX_XX_XX_XX_XX -m org.rockwork.Pebble.setCannedResponses \
+ *  "{'x-nemo.messaging.im': <['Aye','Nay','On my way']>, 'x-nemo.messaging.sms': <['Ok']>, 'com.pebble.sendText':<["Where are you?"]>}"
  */
 void DBusPebble::setCannedResponses(const QVariantMap &cans)
 {
     m_pebble->setCannedMessages(cans);
+}
+QVariantMap DBusPebble::getCannedResponses(const QStringList &groups) const
+{
+    QHash<QString,QStringList> cans = m_pebble->getCannedMessages(groups);
+    QVariantMap ret;
+    foreach(const QString &key,cans.keys()) {
+        ret.insert(key,QVariant::fromValue(cans.value(key)));
+    }
+    return ret;
+}
+
+/**
+ * @brief DBusPebble::setFavoriteContacts
+ * @param cans
+ * @example gdbus call -e -d org.rockwork -o /org/rockwork/B0_B4_48_00_00_00 -m org.rockwork.Pebble.setFavoriteContacts \
+ * '{"Wife":<["+420987654321","+420123456789"]>,"Myself":<["+420555322223"]>}'
+ */
+void DBusPebble::setFavoriteContacts(const QVariantMap &cans)
+{
+    QHash<QString,QStringList> ctxs;
+    foreach(const QString &key, cans.keys()) {
+        ctxs.insert(key,cans.value(key).toStringList());
+    }
+    m_pebble->setCannedContacts(ctxs);
+}
+QVariantMap DBusPebble::getFavoriteContacts(const QStringList &names) const
+{
+    QHash<QString,QStringList> cans = m_pebble->getCannedContacts(names);
+    QVariantMap ret;
+    foreach(const QString &key,cans.keys()) {
+        ret.insert(key,QVariant::fromValue(cans.value(key)));
+    }
+    return ret;
 }
 
 /**

--- a/rockworkd/dbusinterface.cpp
+++ b/rockworkd/dbusinterface.cpp
@@ -21,6 +21,7 @@ DBusPebble::DBusPebble(Pebble *pebble, QObject *parent):
     connect(pebble, &Pebble::imperialUnitsChanged, this, &DBusPebble::ImperialUnitsChanged);
     connect(pebble, &Pebble::profileConnectionSwitchChanged, this, &DBusPebble::onProfileConnectionSwitchChanged);
     connect(pebble, &Pebble::calendarSyncEnabledChanged, this, &DBusPebble::CalendarSyncEnabledChanged);
+    connect(pebble, &Pebble::weatherLocationsChanged, this, &DBusPebble::WeatherLocationsChanged);
     connect(pebble, &Pebble::devConServerStateChanged, this, &DBusPebble::DevConnectionChanged);
     connect(pebble, &Pebble::devConCloudStateChanged, this, &DBusPebble::DevConnCloudChanged);
     connect(pebble, &Pebble::oauthTokenChanged, this, &DBusPebble::oauthTokenChanged);
@@ -208,6 +209,50 @@ QString DBusPebble::accountName() const
 QString DBusPebble::accountEmail() const
 {
     return m_pebble->accountEmail();
+}
+
+void DBusPebble::setWeatherApiKey(const QString &key)
+{
+    m_pebble->setWeatherApiKey(key);
+}
+
+void DBusPebble::setWeatherUnits(const QString &u)
+{
+    m_pebble->setWeatherUnits(u);
+}
+QString DBusPebble::WeatherUnits() const
+{
+    return m_pebble->getWeatherUnits();
+}
+
+/**
+ * @brief DBusPebble::SetWeatherLocations - Sets the locations for WeatherProvider as well as storing locations in BlobDB.
+ * First location MUST be Current Location, although the name could be localized string (Eg. "Aktueller Standort")
+ * @param locs a{as} - Array of String Arrays - each nested array represents ["Location Name", "Lattitude", "Longitude"]
+ * @example gdbus call -e -d org.rockwork -o /org/rockwork/B0_B4_48_00_00_00 -m org.rockwork.Pebble.SetWeatherLocations "[<['Current Location','0','0']>]"
+ * gdbus call -e -d org.rockwork -o /org/rockwork/B0_B4_48_00_00_00 -m org.rockwork.Pebble.SetWeatherLocations "[<['Current Location','0','0']>,<['London','51.508530','-0.125740']>]"
+ */
+void DBusPebble::SetWeatherLocations(const QVariantList &locs)
+{
+    m_pebble->setWeatherLocations(locs);
+}
+QVariantList DBusPebble::WeatherLocations() const
+{
+    return m_pebble->getWeatherLocations();
+}
+
+/**
+ * @brief DBusPebble::InjectWeatherData - Injects the data into BlobDB to show in Pebble's Weather WatchApp
+ * @param loc_name string - Exact name of the pre-set location
+ * @param conditions a{sv} - Current weather conditions for given location
+ * @example gdbus call -e -d org.rockwork -o /org/rockwork/B0_B4_48_00_00_00 -m org.rockwork.Pebble.InjectWeatherData "Current Location" \
+ *          "{'text':<'Sonnenschein'>,'today_hi':<29>,'today_low':<16>,'temperature':<27>,'today_icon':<7>,'tomorrow_icon':<6>,'tomorrow_hi':<25>,'tomorrow_low':<12>}"
+ */
+void DBusPebble::InjectWeatherData(const QString &loc_name, const QVariantMap &obj)
+{
+    if(!obj.contains("text") || !obj.contains("temperature"))
+        return;
+    m_pebble->injectWeatherConditions(loc_name,obj);
 }
 
 bool DBusPebble::DevConnectionEnabled() const

--- a/rockworkd/dbusinterface.h
+++ b/rockworkd/dbusinterface.h
@@ -81,6 +81,9 @@ public slots:
 
     QVariantMap cannedResponses() const;
     void setCannedResponses(const QVariantMap &cans);
+    QVariantMap getCannedResponses(const QStringList &groups) const;
+    void setFavoriteContacts(const QVariantMap &cans);
+    QVariantMap getFavoriteContacts(const QStringList &names) const;
 
     void voiceSessionResult(const QString &dumpFile, const QVariantList &sentences);
 

--- a/rockworkd/dbusinterface.h
+++ b/rockworkd/dbusinterface.h
@@ -32,6 +32,7 @@ signals:
     void ProfileWhenConnectedChanged();
     void ProfileWhenDisconnectedChanged();
     void CalendarSyncEnabledChanged();
+    void WeatherLocationsChanged(const QVariantList &locations);
 
     void DevConnectionChanged(const bool state);
     void DevConnCloudChanged(const bool state);
@@ -109,6 +110,13 @@ public slots:
     QStringList Screenshots() const;
     void RemoveScreenshot(const QString &filename);
     void DumpLogs(const QString &fileName) const;
+
+    QString WeatherUnits() const;
+    void setWeatherUnits(const QString &u);
+    void setWeatherApiKey(const QString &key);
+    QVariantList WeatherLocations() const;
+    void SetWeatherLocations(const QVariantList &locs);
+    void InjectWeatherData(const QString &loc_name, const QVariantMap &conditions);
 
     QVariantMap HealthParams() const;
     void SetHealthParams(const QVariantMap &healthParams);

--- a/rockworkd/libpebble/appmanager.cpp
+++ b/rockworkd/libpebble/appmanager.cpp
@@ -9,6 +9,7 @@
 #include "watchdatawriter.h"
 #include "uploadmanager.h"
 #include "sendtextapp.h"
+#include "weatherapp.h"
 
 #include <libintl.h>
 
@@ -69,7 +70,7 @@ void AppManager::rescan()
     m_appList.append(music.uuid());
     m_apps.insert(music.uuid(), music);
     if(m_pebble->capabilities().testFlag(CapabilityWeather)) {
-        AppInfo weather(QUuid("61b22bc8-1e29-460d-a236-3fe409a439ff"), false, gettext("Weather"), gettext("System app"), true);
+        AppInfo weather(WeatherApp::appUUID, false, gettext("Weather"), gettext("System app"), true);
         m_appList.append(weather.uuid());
         m_apps.insert(weather.uuid(), weather);
     }

--- a/rockworkd/libpebble/appmanager.cpp
+++ b/rockworkd/libpebble/appmanager.cpp
@@ -8,6 +8,7 @@
 #include "watchdatareader.h"
 #include "watchdatawriter.h"
 #include "uploadmanager.h"
+#include "sendtextapp.h"
 
 #include <libintl.h>
 
@@ -73,7 +74,7 @@ void AppManager::rescan()
         m_apps.insert(weather.uuid(), weather);
     }
     if(m_pebble->capabilities().testFlag(CapabilitySendSMS)) {
-        AppInfo sendsms(QUuid("0863fc6a-66c5-4f62-ab8a-82ed00a98b5d"), false, gettext("Send SMS"), gettext("System app"), true);
+        AppInfo sendsms(SendTextApp::appUUID, false, SendTextApp::appName, gettext("System app"), true);
         m_appList.append(sendsms.uuid());
         m_apps.insert(sendsms.uuid(), sendsms);
     }

--- a/rockworkd/libpebble/appmetadata.cpp
+++ b/rockworkd/libpebble/appmetadata.cpp
@@ -54,6 +54,11 @@ void AppMetadata::setAppName(const QString &appName)
     m_appName = appName;
 }
 
+QByteArray AppMetadata::itemKey() const
+{
+    return m_uuid.toRfc4122();
+}
+
 QByteArray AppMetadata::serialize() const
 {
     QByteArray ret;
@@ -70,4 +75,3 @@ QByteArray AppMetadata::serialize() const
     writer.writeFixedString(96, m_appName);
     return ret;
 }
-

--- a/rockworkd/libpebble/appmetadata.h
+++ b/rockworkd/libpebble/appmetadata.h
@@ -3,7 +3,7 @@
 
 #include "watchconnection.h"
 
-class AppMetadata: public PebblePacket
+class AppMetadata: public BlobDbItem
 {
 public:
     AppMetadata();
@@ -18,6 +18,7 @@ public:
     void setAppFaceTemplateId(quint8 templateId);
     void setAppName(const QString &appName);
 
+    QByteArray itemKey() const;
     QByteArray serialize() const;
 signals:
 

--- a/rockworkd/libpebble/blobdb.h
+++ b/rockworkd/libpebble/blobdb.h
@@ -3,11 +3,11 @@
 
 #include "watchconnection.h"
 #include "pebble.h"
-#include "timelineitem.h"
-#include "healthparams.h"
-#include "appmetadata.h"
 
 #include <QObject>
+
+class AppMetadata;
+class TimelineItem;
 
 class BlobDB : public QObject
 {
@@ -19,12 +19,11 @@ public:
         BlobDBIdApp = 2,
         BlobDBIdReminder = 3,
         BlobDBIdNotification = 4,
-        //WeatherForecast = 5,
-        //AutoReplySettings = 6,
-        BlobDBIdAppSettings = 7
-        // ...
-        // WeatherApp = 9
-
+        BlobDBIdWeatherData = 5,
+        blobDBIdSendTextData = 6,
+        BlobDBIdAppSettings = 7, // this is rather HealthAppSettings
+        BlobDBIdContacts = 8,
+        BlobDBIdAppConfigs = 9 // Config Data References
     };
     enum Operation {
         OperationInsert = 0x01,
@@ -57,8 +56,8 @@ public:
     void insertAppMetaData(const AppInfo &info, const bool force=false);
     void removeApp(const AppInfo &info);
 
-    void insert(BlobDBId database, const TimelineItem &item);
-    void remove(BlobDBId database, const QUuid &uuid);
+    void insert(BlobDBId database, const BlobDbItem &item);
+    void remove(BlobDBId database, const QByteArray &key);
     void clear(BlobDBId database);
 
     void setHealthParams(const HealthParams &healthParams);
@@ -71,7 +70,7 @@ private slots:
 
 signals:
     void appInserted(const QUuid &uuid);
-    void blobCommandResult(BlobDBId db, Operation cmd, const QUuid &uuid, Status ack);
+    void blobCommandResult(BlobDBId db, Operation cmd, const QByteArray &key, Status ack);
     void notifyTimeline(const QDateTime &ts, const QUuid &key, const TimelineItem &val);
 
 private:

--- a/rockworkd/libpebble/pebble.cpp
+++ b/rockworkd/libpebble/pebble.cpp
@@ -145,7 +145,7 @@ Pebble::Pebble(const QBluetoothAddress &address, QObject *parent):
 
     settings.beginGroup(WeatherApp::appConfigKey);
     if(!settings.value("apiKey").toString().isEmpty()) {
-        m_weatherProv = new WeatherProviderTWC(this,m_weatherApp);
+        m_weatherProv = new WeatherProviderTWC(this,m_connection,m_weatherApp);
         m_weatherProv->setUnits(settings.value("units",'m').toChar());
         m_weatherProv->setLanguage(settings.value("language","en-GB").toString());
         ((WeatherProviderTWC*)m_weatherProv)->setApiKey(settings.value("apiKey").toString());

--- a/rockworkd/libpebble/pebble.h
+++ b/rockworkd/libpebble/pebble.h
@@ -27,6 +27,7 @@ class DataLoggingEndpoint;
 class DevConnection;
 class TimelineManager;
 class TimelineSync;
+class SendTextApp;
 class VoiceEndpoint;
 struct SpeexInfo;
 struct AudioStream;
@@ -96,6 +97,9 @@ public:
     QNetworkAccessManager *nam() const;
     QVariantMap cannedMessages() const;
     void setCannedMessages(const QVariantMap &cans) const;
+    QHash<QString,QStringList> getCannedMessages(const QStringList &groups = QStringList()) const;
+    void setCannedContacts(const QHash<QString,QStringList> &cans);
+    QHash<QString,QStringList> getCannedContacts(const QStringList &names = QStringList()) const;
     qint32 timelineWindowStart() const;
     qint32 timelineWindowFade() const;
     qint32 timelineWindowEnd() const;
@@ -170,6 +174,8 @@ private slots:
     void appDownloadFinished(const QString &id);
     void appInstalled(const QUuid &uuid);
     void appStarted(const QUuid &uuid);
+    void saveTextContacts() const;
+    void saveTextMessages(const QByteArray &key) const;
     void muteNotificationSource(const QString &source);
     void voiceSessionRequest(const QUuid &appUuid, const SpeexInfo &codec);
     void voiceAudioStream(quint16 sid, const AudioStream &frames);
@@ -194,6 +200,9 @@ signals:
     void upgradingFirmwareChanged();
     void languagePackChanged();
     void logsDumped(bool success);
+    void contactsChanged() const;
+    void messagesChanged() const;
+    void weatherLocationsChanged(const QVariantList &locations) const;
     void voiceSessionSetup(const QString &fileName, const QString &format, const QString &appUuid);
     void voiceSessionStream(const QString &fileName);
     void voiceSessionDumped(const QString &fileName);
@@ -237,6 +246,7 @@ private:
     FirmwareDownloader *m_firmwareDownloader;
     WatchLogEndpoint *m_logEndpoint;
     DataLoggingEndpoint *m_dataLogEndpoint;
+    SendTextApp * m_sendTextApp;
     VoiceEndpoint * m_voiceEndpoint;
     QTemporaryFile* m_voiceSessDump = nullptr;
 

--- a/rockworkd/libpebble/pebble.h
+++ b/rockworkd/libpebble/pebble.h
@@ -28,6 +28,8 @@ class DevConnection;
 class TimelineManager;
 class TimelineSync;
 class SendTextApp;
+class WeatherApp;
+class WeatherProvider;
 class VoiceEndpoint;
 struct SpeexInfo;
 struct AudioStream;
@@ -108,6 +110,12 @@ public slots:
     void setTimelineWindow(qint32 start, qint32 fade, qint32 end);
     void setOAuthToken(const QString &token);
     void setSyncAppsFromCloud(bool enable);
+    void setWeatherApiKey(const QString &key);
+    void setWeatherUnits(const QString &u);
+    QString getWeatherUnits() const;
+    QVariantList getWeatherLocations() const;
+    void setWeatherLocations(const QVariantList &locations);
+    void injectWeatherConditions(const QString &location, const QVariantMap &conditions);
     QVariantMap notificationsFilter() const;
     void setNotificationFilter(const QString &sourceId, const QString &name, const QString &icon, const NotificationFilter enabled);
     void setNotificationFilter(const QString &sourceId, const NotificationFilter enabled);
@@ -180,6 +188,7 @@ private slots:
     void voiceSessionRequest(const QUuid &appUuid, const SpeexInfo &codec);
     void voiceAudioStream(quint16 sid, const AudioStream &frames);
     void voiceSessionClose(quint16 sesId);
+    void saveWeatherLocations() const;
 
     void resetPebble();
     void syncApps();
@@ -247,6 +256,8 @@ private:
     WatchLogEndpoint *m_logEndpoint;
     DataLoggingEndpoint *m_dataLogEndpoint;
     SendTextApp * m_sendTextApp;
+    WeatherApp * m_weatherApp;
+    WeatherProvider * m_weatherProv;
     VoiceEndpoint * m_voiceEndpoint;
     QTemporaryFile* m_voiceSessDump = nullptr;
 

--- a/rockworkd/libpebble/sendtextapp.cpp
+++ b/rockworkd/libpebble/sendtextapp.cpp
@@ -1,0 +1,263 @@
+#include "sendtextapp.h"
+
+#include "blobdb.h"
+#include "timelineitem.h"
+
+#include "platforminterface.h"
+
+#include <libintl.h>
+
+const QUuid SendTextApp::actionUUID = QUuid("0f71aaba-5814-4b5c-96e2-c9828c9734cb");
+const QUuid SendTextApp::appUUID = QUuid("0863fc6a-66c5-4f62-ab8a-82ed00a98b5d");
+const char* SendTextApp::appName = gettext("Send Text");
+const QSet<const QByteArray> SendTextApp::appKeys = {{"com.pebble.sendText","com.pebble.android.phone"}};
+
+/**
+ * @brief The BlobTextMessage class
+ */
+class BlobTextMessage : public BlobDbItem
+{
+public:
+    BlobTextMessage(const QString &key, const QStringList &messages, quint8 attrId = 8);
+
+    QByteArray itemKey() const override {return m_key;}
+    QByteArray serialize() const override;
+private:
+    QByteArray m_key;
+    quint32 m_flags = 0;
+    quint8 m_attCnt = 0;
+    quint8 m_actCnt = 1;
+    TimelineAction m_action;
+};
+BlobTextMessage::BlobTextMessage(const QString &key, const QStringList &messages, quint8 attrId):
+    BlobDbItem(),
+    m_key(key.toUtf8()),
+    m_action(0,TimelineAction::TypeResponse)
+{
+    TimelineAttribute att(attrId);
+    att.setStringList(messages);
+    m_action.appendAttribute(att);
+}
+QByteArray BlobTextMessage::serialize() const
+{
+    QByteArray ret;
+    //WatchDataWriter w(&ret);
+    //w.writeLE<quint32>(m_flags);
+    // till above is clarified/confirmed - below makes more sense
+    ret.fill(0,4);
+    ret.append(m_attCnt);
+    ret.append(m_actCnt);
+    ret.append(m_action.serialize());
+    return ret;
+}
+
+/**
+ * @brief The BlobContacts class
+ */
+class BlobContacts : public BlobDbItem
+{
+public:
+    static const int maxContacts = 10;
+    static const QByteArray blobKey;
+    struct ContactEntry {
+        QUuid contactId;
+        QUuid methodId;
+        quint8 methodType = 1;
+    };
+
+    BlobContacts():BlobDbItem() {}
+    BlobContacts(const QList<ContactEntry> &contacts):
+        BlobDbItem()
+    {
+        setEntries(contacts);
+    }
+    void setEntries(const QList<ContactEntry> &contacts) {
+        m_contacts = (contacts.length() < maxContacts) ? contacts : contacts.mid(0,maxContacts);
+    }
+    void append(const ContactEntry &entry) {
+        if(m_contacts.length()<maxContacts)
+            m_contacts.append(entry);
+    }
+    void append(const QList<ContactEntry> &entries) {
+        if(m_contacts.length()+entries.length()>maxContacts) return;
+        m_contacts.append(entries);
+    }
+
+    QByteArray itemKey() const override {return blobKey;}
+    QByteArray serialize() const override;
+private:
+    QList<ContactEntry> m_contacts;
+};
+const QByteArray BlobContacts::blobKey = QByteArray("sendTextApp",11);
+
+QByteArray BlobContacts::serialize() const
+{
+    QByteArray ret;
+    ret.append(m_contacts.length());
+    for(QList<ContactEntry>::const_iterator it=m_contacts.begin();it!=m_contacts.end();it++) {
+        ret.append(it->contactId.toRfc4122());
+        ret.append(it->methodId.toRfc4122());
+        ret.append(it->methodType);
+    }
+    ret.append(QByteArray((maxContacts-m_contacts.length())*33,'\0'));
+    return ret;
+}
+
+/**
+ * @brief The BlobContact class
+ */
+class BlobContact : public BlobDbItem
+{
+public:
+    BlobContact(const QString &name, const QStringList &numbers);
+    BlobContact(const SendTextApp::Contact &contact):BlobContact(contact.name,contact.numbers) {}
+
+    QList<BlobContacts::ContactEntry> getEntries() const;
+
+    QByteArray itemKey() const override {return m_key.toRfc4122();}
+    QByteArray serialize() const override;
+private:
+    QUuid m_key;
+    quint32 m_flags = 0;
+    quint8 m_attCnt = 1;
+    quint8 m_mthCnt = 0;
+    TimelineAttribute m_title;
+    // This is mere speculation, only QUuid and Strlen(quint16)+Str(char[Strlen]) are known. AttributeId=0x27 - doesn't exist in layouts.json
+    struct ContactMethod {
+        QUuid methodId;
+        quint8 methodType = 1;
+        quint8 methodNum = 1;
+        TimelineAttribute method;
+    };
+    QList<ContactMethod> m_methods;
+};
+
+BlobContact::BlobContact(const QString &name, const QStringList &numbers):
+    BlobDbItem(),
+    m_key(PlatformInterface::idToGuid(name)),
+    m_mthCnt(numbers.length())
+{
+    m_title = TimelineAttribute(1,name);
+    foreach (const QString &num, numbers) {
+        TimelineAttribute att(0x27);
+        att.setString(num);
+        ContactMethod mtd;
+        mtd.methodId = PlatformInterface::idToGuid(num);
+        mtd.method = att;
+        m_methods.append(mtd);
+    }
+}
+
+QList<BlobContacts::ContactEntry> BlobContact::getEntries() const
+{
+    QList<BlobContacts::ContactEntry> ret;
+    for(int i=0;i<m_methods.length();i++) {
+        BlobContacts::ContactEntry e;
+        e.contactId = m_key;
+        e.methodId = m_methods.at(i).methodId;
+        e.methodType = m_methods.at(i).methodType;
+        ret.append(e);
+    }
+    return ret;
+}
+
+QByteArray BlobContact::serialize() const
+{
+    QByteArray ret;
+    ret.fill('\0',4);
+    ret.prepend(m_key.toRfc4122());
+    ret.append(m_attCnt);
+    ret.append(m_mthCnt);
+    ret.append(m_title.serialize());
+    foreach(const ContactMethod &m, m_methods) {
+        ret.append(m.methodId.toRfc4122());
+        ret.append(m.methodType);
+        ret.append(m.methodNum);
+        ret.append(m.method.serialize());
+    }
+    return ret;
+}
+
+/**
+ * @brief SendTextApp::SendTextApp
+ * @param pebble
+ * @param connection
+ */
+SendTextApp::SendTextApp(Pebble *pebble, WatchConnection *connection):
+    QObject(pebble),
+    m_pebble(pebble),
+    m_connection(connection)
+{
+    connect(pebble->blobdb(), &BlobDB::blobCommandResult, this, &SendTextApp::blobdbAckHandler);
+}
+
+void SendTextApp::setCannedMessages(const QHash<QString, QStringList> &cans)
+{
+    foreach (const QString &key, cans.keys()) {
+        if(appKeys.contains(key.toUtf8())) {
+            qDebug() << "Inserting" << key << cans.value(key);
+            m_pebble->blobdb()->insert(BlobDB::blobDBIdSendTextData,BlobTextMessage(key,cans.value(key)));
+            m_messages.insert(key.toUtf8(),cans.value(key));
+        }
+    }
+}
+
+void SendTextApp::wipeCannedMessages()
+{
+    m_pebble->blobdb()->clear(BlobDB::blobDBIdSendTextData);
+    m_messages.clear();
+}
+
+QStringList SendTextApp::getCannedMessages(const QByteArray &key) const
+{
+    return m_messages.value(key);
+}
+
+void SendTextApp::setCannedContacts(const QList<Contact> &favs)
+{
+    BlobContacts bcs;
+    m_contacts.clear();
+    for(QList<Contact>::const_iterator it=favs.begin(); it!=favs.end(); it++) {
+        BlobContact bc(*it);
+        if(m_contacts.length()>=10) break;
+        m_pebble->blobdb()->insert(BlobDB::BlobDBIdContacts,bc);
+        bcs.append(bc.getEntries());
+        m_contacts.append(*it);
+        qDebug() << "Adding contacts" << it->name << it->numbers;// << bc.serialize().toHex();
+    }
+    //qDebug() << "Inserting config blob" << bcs.serialize().toHex();
+    m_pebble->blobdb()->insert(BlobDB::BlobDBIdAppConfigs,bcs);
+}
+
+void SendTextApp::wipeContacts()
+{
+    m_pebble->blobdb()->remove(BlobDB::BlobDBIdAppConfigs,BlobContacts::blobKey);
+    m_pebble->blobdb()->clear(BlobDB::BlobDBIdContacts);
+    m_contacts.clear();
+}
+
+QList<SendTextApp::Contact> SendTextApp::getCannedContacts() const
+{
+    return m_contacts;
+}
+
+void SendTextApp::blobdbAckHandler(quint8 db, quint8 cmd, const QByteArray &key, quint8 ack)
+{
+    switch(db) {
+    case BlobDB::BlobDBIdAppConfigs:
+    case BlobDB::BlobDBIdContacts:
+    case BlobDB::blobDBIdSendTextData:
+        break;
+    default:
+        return;
+    }
+    if(db==BlobDB::BlobDBIdAppConfigs) {
+        if(key != BlobContacts::blobKey) return;
+        if(ack == BlobDB::StatusSuccess)
+            emit contactBlobSet();
+    } else if(db==BlobDB::blobDBIdSendTextData) {
+        if(ack==BlobDB::StatusSuccess)
+            emit messageBlobSet(key);
+    }
+    qDebug() << "BlobDb result for" << db << cmd << ack << key.toHex();
+}

--- a/rockworkd/libpebble/sendtextapp.h
+++ b/rockworkd/libpebble/sendtextapp.h
@@ -1,0 +1,54 @@
+#ifndef SENDTEXTAPP_H
+#define SENDTEXTAPP_H
+
+#include <QObject>
+#include <QHash>
+#include <QStringList>
+
+/**
+ * @brief The SendTextApp class
+ */
+class Pebble;
+class WatchConnection;
+
+class SendTextApp: public QObject
+{
+    Q_OBJECT
+public:
+    static const QUuid actionUUID;
+    static const QUuid appUUID;
+    static const char* appName;
+    static const QSet<const QByteArray> appKeys;
+
+    struct Contact {
+        QString name;
+        QStringList numbers;
+    };
+
+    SendTextApp(Pebble *pebble, WatchConnection *connection);
+
+    QStringList getCannedMessages(const QByteArray &key) const;
+    QList<Contact> getCannedContacts() const;
+
+signals:
+    void messageBlobSet(const QByteArray &key);
+    void contactBlobSet();
+
+public slots:
+    void setCannedMessages(const QHash<QString,QStringList> &cans);
+    void wipeCannedMessages();
+    void setCannedContacts(const QList<Contact> &favs);
+    void wipeContacts();
+
+private slots:
+    void blobdbAckHandler(quint8 db, quint8 cmd, const QByteArray &key, quint8 ack);
+
+private:
+    QHash<QByteArray,QStringList> m_messages;
+    QList<Contact> m_contacts;
+
+    Pebble *m_pebble;
+    WatchConnection *m_connection;
+};
+
+#endif // SENDTEXTAPP_H

--- a/rockworkd/libpebble/timelineitem.cpp
+++ b/rockworkd/libpebble/timelineitem.cpp
@@ -212,11 +212,11 @@ QString TimelineAttribute::getString() const
 void TimelineAttribute::setStringList(const QStringList &values, int max)
 {
     m_content.clear();
-    foreach (const QString &value, values) {
-        if (!m_content.isEmpty()) {
+    for(int i=0;i<values.size();i++) {
+        if (i>0) {
             m_content.append('\0');
         }
-        m_content.append(value.toUtf8());
+        m_content.append(values.at(i).toUtf8());
         if(max>0 && m_content.length()>max) {
             m_content.resize(max);
             return;

--- a/rockworkd/libpebble/timelineitem.cpp
+++ b/rockworkd/libpebble/timelineitem.cpp
@@ -7,7 +7,7 @@ TimelineItem::TimelineItem(TimelineItem::Type type, Flags flags, const QDateTime
 }
 
 TimelineItem::TimelineItem(const QUuid &uuid, TimelineItem::Type type, Flags flags, const QDateTime &timestamp, quint16 duration):
-    PebblePacket(),
+    BlobDbItem(),
     m_itemId(uuid),
     m_timestamp(timestamp),
     m_duration(duration),
@@ -64,6 +64,11 @@ QList<TimelineAttribute> TimelineItem::attributes() const
 QList<TimelineAction> TimelineItem::actions() const
 {
     return m_actions;
+}
+
+QByteArray TimelineItem::itemKey() const
+{
+    return itemId().toRfc4122();
 }
 
 QByteArray TimelineItem::serialize() const

--- a/rockworkd/libpebble/timelineitem.h
+++ b/rockworkd/libpebble/timelineitem.h
@@ -108,7 +108,7 @@ private:
     QList<TimelineAttribute> m_attributes;
 };
 
-class TimelineItem: public PebblePacket
+class TimelineItem: public BlobDbItem
 {
 public:
     enum Type {
@@ -144,6 +144,7 @@ public:
     QList<TimelineAttribute> attributes() const;
     QList<TimelineAction> actions() const;
 
+    QByteArray itemKey() const override;
     QByteArray serialize() const override;
     bool deserialize(const QByteArray &data) override;
 

--- a/rockworkd/libpebble/timelinemanager.cpp
+++ b/rockworkd/libpebble/timelinemanager.cpp
@@ -896,7 +896,7 @@ void TimelineManager::insert(const TimelinePin &pin)
 void TimelineManager::remove(const TimelinePin &pin)
 {
     qDebug() << "removing TimelinePin from blobdb:" << pin.blobId() << pin.guid().toString();
-    m_pebble->blobdb()->remove(pin.blobId(), pin.guid());
+    m_pebble->blobdb()->remove(pin.blobId(), pin.guid().toRfc4122());
 }
 
 void TimelineManager::clearTimeline(const QUuid &parent)
@@ -948,7 +948,7 @@ void TimelineManager::wipeSubscription(const QString &topic)
     }
 }
 
-void TimelineManager::blobdbAckHandler(BlobDB::BlobDBId db, BlobDB::Operation cmd, const QUuid &uuid, BlobDB::Status ack)
+void TimelineManager::blobdbAckHandler(BlobDB::BlobDBId db, BlobDB::Operation cmd, const QByteArray &key, BlobDB::Status ack)
 {
     switch(db) {
     case BlobDB::BlobDBIdPin:
@@ -958,9 +958,9 @@ void TimelineManager::blobdbAckHandler(BlobDB::BlobDBId db, BlobDB::Operation cm
     default:
         return;
     }
-    TimelinePin *pin = getPin(uuid);
+    TimelinePin *pin = getPin(QUuid::fromRfc4122(key));
     if(pin==nullptr && cmd != BlobDB::OperationClear) {
-        qDebug() << "Result for non-existing pin" << uuid << db << cmd << ack;
+        qDebug() << "Result for non-existing pin" << key.toHex() << db << cmd << ack;
         return;
     }
     qDebug() << ((ack==BlobDB::StatusSuccess)?"ACK":"NACK") << "for" << ((cmd==BlobDB::OperationInsert)?"insert":"delete") << "of" << (cmd==BlobDB::OperationClear ? QString::number(db) : pin->guid().toString());

--- a/rockworkd/libpebble/timelinemanager.cpp
+++ b/rockworkd/libpebble/timelinemanager.cpp
@@ -53,7 +53,7 @@ TimelinePin::TimelinePin(const TimelinePin &src):
     m_sent(src.m_sent)
 {
     //buildActions();
-    qDebug() << "Pin deep copy - be sure to know what you're doing" << m_uuid;
+    //qDebug() << "Pin deep copy - be sure to know what you're doing" << m_uuid;
     m_pending = src.m_pending;
 }
 TimelinePin::TimelinePin(const QJsonObject &obj, TimelineManager *manager, const QUuid &uuid, const TimelinePin *parent):
@@ -634,7 +634,7 @@ TimelineItem & TimelineManager::parseActions(TimelineItem &timelineItem, const Q
             if(it.key() == "type")
                 continue;
             TimelineAttribute attr=parseAttribute(it.key(),it.value());
-            qDebug() << "With attribute" << it.key() << it.value() << attr.type();
+            //qDebug() << "With attribute" << it.key() << it.value() << attr.type();
             if(attr.type()>0)
                 tlAct.appendAttribute(attr);
         }
@@ -830,7 +830,7 @@ void TimelineManager::doMaintenance()
         //qDebug() << "Iterating timestamp" << it.key() << "with" << it.value().count() << "items";
         if(it.value().isEmpty()) {
             m_mtx_pinStorage.lock();
-            m_pin_idx_time.erase(it);
+            it = m_pin_idx_time.erase(it);
             m_mtx_pinStorage.unlock();
             continue;
         }
@@ -1002,7 +1002,7 @@ void TimelineManager::blobdbAckHandler(BlobDB::BlobDBId db, BlobDB::Operation cm
 void TimelineManager::insertTimelinePin(const QJsonObject &json)
 {
     QJsonObject obj(json);
-    qDebug() << "Incoming pin:" << QJsonDocument(obj).toJson();
+    //qDebug() << "Incoming pin:" << QJsonDocument(obj).toJson();
     TimelinePin pin(obj,this);
     if(pin.type() == TimelineItem::TypeNotification) {
         // Simple persistence checks for volatile (system) notification. Also do some sanity checks
@@ -1036,15 +1036,15 @@ void TimelineManager::insertTimelinePin(const QJsonObject &json)
     }
     // At this stage we are positive to insert the pin.
     // Insert it first so that user could open it from notification or reminder
-    qDebug() << "Sending pin" << pin.guid() << pin.time().toString(Qt::ISODate);
+    //qDebug() << "Sending pin" << pin.guid() << pin.time().toString(Qt::ISODate);
     pin.send();
     TimelinePin notice = pin.makeNotification(old);
     if(notice.isValid()) {
-        qDebug() << "Sending notification" << notice.guid() << "for pin" << pin.guid();
+        //qDebug() << "Sending notification" << notice.guid() << "for pin" << pin.guid();
         notice.send(); // Store, add to index and send to watches
     }
     if(!pin.reminders().isEmpty()) {
-        qDebug() << "Sending" << pin.reminders().count() << "reminders for pin" << pin.guid();
+        //qDebug() << "Sending" << pin.reminders().count() << "reminders for pin" << pin.guid();
         foreach(const TimelinePin &rmd,pin.makeReminders()) {
             qDebug() << rmd.guid() << rmd.time().toString(Qt::ISODate);
             rmd.send();

--- a/rockworkd/libpebble/timelinemanager.cpp
+++ b/rockworkd/libpebble/timelinemanager.cpp
@@ -1,5 +1,6 @@
 #include "timelinemanager.h"
 #include "platforminterface.h"
+#include "sendtextapp.h"
 #include "blobdb.h"
 
 #include "watchdatareader.h"
@@ -338,7 +339,6 @@ QList<TimelineAttribute> TimelinePin::handleAction(TimelineAction::Type atype, q
     return attributes;
 }
 
-QUuid TimelineManager::appSendText = QUuid("0f71aaba-5814-4b5c-96e2-c9828c9734cb");
 /**
  * @brief TimelineManager::TimelineManager
  * @param pebble
@@ -666,7 +666,7 @@ void TimelineManager::actionHandler(const QByteArray &actionReply)
     const TimelinePin *source = getPin(notificationId);
     if (source==nullptr) {
         status = BlobDB::ResponseError;
-        if(notificationId == appSendText && param.contains("title") && param.contains("sender")) {
+        if(notificationId == SendTextApp::actionUUID && param.contains("title") && param.contains("sender")) {
             emit actionSendText(param.value("sender").toString(),param.value("title").toString());
             attributes.append(parseAttribute("largeIcon",QString("system://images/RESULT_SENT")));
             attributes.append({getAttr("subtitle").id,QString("Sent!")});

--- a/rockworkd/libpebble/timelinemanager.h
+++ b/rockworkd/libpebble/timelinemanager.h
@@ -141,7 +141,7 @@ signals:
 private slots:
     void actionHandler(const QByteArray &data);
     void notifyHandler(const QDateTime &ts, const QUuid &key, const TimelineItem &val);
-    void blobdbAckHandler(BlobDB::BlobDBId db, BlobDB::Operation cmd, const QUuid &uuid, BlobDB::Status ack);
+    void blobdbAckHandler(BlobDB::BlobDBId db, BlobDB::Operation cmd, const QByteArray &key, BlobDB::Status ack);
     void doMaintenance();
 
 protected:

--- a/rockworkd/libpebble/timelinemanager.h
+++ b/rockworkd/libpebble/timelinemanager.h
@@ -108,8 +108,6 @@ class TimelineManager : public QObject
     Q_OBJECT
     friend class TimelinePin;
 public:
-    static QUuid appSendText;
-
     TimelineManager(Pebble *pebble, WatchConnection *connection);
 
     // Timeline Layout

--- a/rockworkd/libpebble/watchconnection.h
+++ b/rockworkd/libpebble/watchconnection.h
@@ -21,6 +21,12 @@ public:
     virtual bool deserialize(const QByteArray &data) {qCritical() << "Attempt to deserialize using unimplemented method from" << data.toHex();return false;}
 };
 
+class BlobDbItem : public PebblePacket {
+public:
+    BlobDbItem() : PebblePacket() {}
+    virtual QByteArray itemKey() const = 0;
+};
+
 class Callback
 {
 public:

--- a/rockworkd/libpebble/weatherapp.cpp
+++ b/rockworkd/libpebble/weatherapp.cpp
@@ -1,0 +1,454 @@
+#include "weatherapp.h"
+
+#include "blobdb.h"
+#include "watchdatawriter.h"
+#include "platforminterface.h"
+
+#include <QJsonArray>
+
+#include <libintl.h>
+
+/**
+ * @brief The WeatherConfigurations class is used to store weather condition references
+ * to BlobDB. It just lists the BlobDB Keys (up to 6) represented by UUIDs.
+ */
+class WeatherConfigurations: public BlobDbItem
+{
+public:
+    static const QByteArray blobKey;
+    static const quint16 blobLength = 0x61;
+
+    WeatherConfigurations(const QList<QUuid> &configs)
+    {m_confs = configs.length()>6 ? configs.mid(0,6):configs;}
+
+    QByteArray itemKey() const;
+    QByteArray serialize() const;
+
+private:
+    QList<QUuid> m_confs;
+};
+const QByteArray WeatherConfigurations::blobKey = QByteArray("weatherApp",10);
+
+QByteArray WeatherConfigurations::itemKey() const
+{
+    return blobKey;
+}
+
+QByteArray WeatherConfigurations::serialize() const
+{
+    QByteArray ret;
+    ret.append(m_confs.length());
+    foreach(const QUuid &uuid,m_confs) {
+        ret.append(uuid.toRfc4122());
+    }
+    if(m_confs.length()<6)
+        ret.append(QByteArray(16*(6-m_confs.length()),'\0'));
+    return ret;
+}
+/**
+ * @brief The WeatherObservation class used to store current weather condition into BlobDB.
+ * Stored data is then used by WeatherApp to show the condition and icon. BlobDB Key MUST
+ * be referenced in WeatherConfiguration section.
+ */
+class WeatherObservation: public BlobDbItem
+{
+public:
+    WeatherObservation(const WeatherApp::Location &loc, const WeatherApp::Observation &obs);
+
+    struct Condition {
+        QString location;
+        QString condition;
+    };
+
+    QByteArray itemKey() const;
+    QByteArray serialize() const;
+
+    const QUuid & key() const {return m_configKey;}
+
+private:
+
+    QUuid m_configKey;
+    quint8 m_type = 0x3;
+    qint16 m_current_temp = SHRT_MAX;
+    quint8 m_today_cond = 0;
+    qint16 m_today_temp_hi = SHRT_MAX;
+    qint16 m_today_temp_low = SHRT_MAX;
+    quint8 m_tomorrow_cond = 0;
+    qint16 m_tomorrow_temp_hi = SHRT_MAX;
+    qint16 m_tomorrow_temp_low = SHRT_MAX;
+    time_t m_sample_time = 0;
+    Condition m_condition;
+    // Should probably be like this, but...
+    //QList<Condition> m_conditions;
+};
+
+WeatherObservation::WeatherObservation(const WeatherApp::Location &loc, const WeatherApp::Observation &obs):
+    BlobDbItem(),
+    m_configKey(loc.uuid),
+    m_current_temp(obs.temp_now),
+    m_today_cond(obs.today.condition),
+    m_today_temp_hi(obs.today.temp_hi),
+    m_today_temp_low(obs.today.temp_low),
+    m_tomorrow_cond(obs.tomorrow.condition),
+    m_tomorrow_temp_hi(obs.tomorrow.temp_hi),
+    m_tomorrow_temp_low(obs.tomorrow.temp_low)
+{
+    m_condition.location = loc.name;
+    m_condition.condition = obs.text;
+    m_sample_time = obs.timestamp.toUTC().toTime_t();
+}
+
+QByteArray WeatherObservation::itemKey() const
+{
+    return m_configKey.toRfc4122();
+}
+QByteArray WeatherObservation::serialize() const
+{
+    QByteArray ret,str;
+    WatchDataWriter w(&ret),s(&str);
+    ret.append(m_type);
+    w.writeLE<qint16>(m_current_temp);
+    ret.append(m_today_cond);
+    w.writeLE<qint16>(m_today_temp_hi);
+    w.writeLE<qint16>(m_today_temp_low);
+    ret.append(m_tomorrow_cond);
+    w.writeLE<qint16>(m_tomorrow_temp_hi);
+    w.writeLE<qint16>(m_tomorrow_temp_low);
+    w.writeLE<quint32>(m_sample_time);
+    //ret.append(m_conditions.length());
+    ret.append(1); // so far i didn't see more than 1, let's not overcomplicate
+    //for(int i=0;i<m_conditions.length();i++) {
+        //QByteArray b = m_conditions.at(i).location.toUtf8();
+        QByteArray b = m_condition.location.toUtf8();
+        s.writeLE<quint16>(b.length());
+        s.writeBytes(b.length(),b);
+        //b = m_conditions.at(i).condition.toUtf8();
+        b = m_condition.condition.toUtf8();
+        s.writeLE<quint16>(b.length());
+        s.writeBytes(b.length(),b);
+    //}
+    w.writeLE<quint16>(str.length());
+    ret.append(str);
+    return ret;
+}
+
+/**
+ * @brief WeatherApp::Observation::Observation
+ */
+WeatherApp::Observation::Observation(int temp, const QString &text, const Data &today, const Data &tomorrow):
+    temp_now(temp),
+    today(today),
+    tomorrow(tomorrow),
+    text(text)
+{
+    timestamp = QDateTime::currentDateTime();
+}
+WeatherApp::Observation::Observation()
+{
+    temp_now = SHRT_MAX;
+    today = {0,SHRT_MAX,SHRT_MAX};
+    tomorrow = today;
+    text = "";
+}
+
+bool WeatherApp::Observation::operator==(const WeatherApp::Observation &that) const
+{
+    if(temp_now!=that.temp_now) return false;
+    if(today.condition != that.today.condition || today.temp_hi != that.today.temp_hi || today.temp_low != that.today.temp_low) return false;
+    if(tomorrow.condition != that.tomorrow.condition || tomorrow.temp_hi != that.tomorrow.temp_hi || tomorrow.temp_low != tomorrow.temp_low) return false;
+    if(text != that.text) return false;
+    return true;
+}
+bool WeatherApp::Observation::operator !=(const WeatherApp::Observation &that) const
+{
+    return !(*this == that);
+}
+
+/**
+ * @brief WeatherApp::Forecast::Forecast Constructs empty Forecast element
+ * @param locOrder List of strings with locations order used to produce TimelinePin.
+ */
+WeatherApp::Forecast::Forecast(const QStringList &locOrder):
+    m_locOrder(locOrder)
+{
+}
+WeatherApp::Forecast::Forecast(const QStringList &locOrder, const Data &day, const QDateTime &sunrise, const QString &day_icon, const QDateTime &sunset, const QString &night_icon):
+    m_here(day),
+    m_locOrder(locOrder),
+    sunrise(sunrise),
+    sunset(sunset),
+    day_icon(day_icon),
+    night_icon(night_icon)
+{
+}
+
+void WeatherApp::Forecast::initLoc(const Data &day, const QDateTime &_sunrise, const QString &_day_icon, const QDateTime &_sunset, const QString &_night_icon)
+{
+    m_here = day;
+    sunrise = _sunrise;
+    sunset = _sunset;
+    day_icon = _day_icon;
+    night_icon = _night_icon;
+}
+
+void WeatherApp::Forecast::addCity(const QString &name, const Data &day)
+{
+    m_cities.insert(name,day);
+}
+
+void WeatherApp::Forecast::reorder(const QStringList &newOrder)
+{
+    m_locOrder = newOrder;
+}
+
+bool WeatherApp::Forecast::equal(const Forecast &that, int daypart) const
+{
+    if(sunrise != that.sunrise || sunset != that.sunset) return false;
+    if(m_here.min_temp != that.m_here.min_temp || m_here.max_temp != that.m_here.max_temp) return false;
+    if(m_cities.size() != that.m_cities.size()) return false;
+    if(m_locOrder != that.m_locOrder) return false;
+    foreach(const QString &key,m_cities.keys()) {
+        if(!that.m_cities.contains(key)) return false;
+        if(m_cities.value(key).min_temp != that.m_cities.value(key).min_temp) return false;
+        if(m_cities.value(key).max_temp != that.m_cities.value(key).max_temp) return false;
+        if((daypart < 0 || daypart == 0) && m_cities.value(key).day_text != that.m_cities.value(key).day_text) return false;
+        if((daypart < 0 || daypart < 0) && m_cities.value(key).night_text != that.m_cities.value(key).night_text) return false;
+    }
+    if(daypart < 0 || daypart == 0) {
+        if(day_icon != that.day_icon) return false;
+        if(m_here.day_text != that.m_here.day_text) return false;
+    }
+    if(daypart < 0 || daypart > 0) {
+        if(night_icon != that.night_icon) return false;
+        if(m_here.night_text != that.m_here.night_text) return false;
+    }
+    return true;
+}
+bool WeatherApp::Forecast::isValid(bool night) const
+{
+    if(night) {
+        //return (night_icon>0 && !m_here.night_text.isEmpty());
+        return !m_here.night_text.isEmpty(); // not all icons collected yet
+    } else {
+        //return (day_icon>0 && !m_here.day_text.isEmpty());
+        return !m_here.day_text.isEmpty();
+    }
+}
+
+bool WeatherApp::Forecast::isComplete() const
+{
+    return (sunrise.isValid() && sunset.isValid() && m_cities.keys().toSet() == m_locOrder.mid(1).toSet());
+}
+
+QString WeatherApp::Forecast::fmtTmp(int tmp)
+{
+    if(tmp == SHRT_MAX) return "-";
+    return QString("%1\u00b0").arg(QString::number(tmp));
+}
+
+QJsonObject WeatherApp::Forecast::getPin(int daynum, bool night, const QString &provider) const
+{
+    QJsonObject ret,layout;
+    QStringList hs,ps;
+
+    QByteArray uuid = WeatherApp::appUUID.toRfc4122();
+    uuid[15] = (daynum*2)+(night?2:1);
+    QUuid guid = QUuid::fromRfc4122(uuid);
+    ret.insert("id",QString("weather-day%1-%2").arg(QString::number(daynum),night?"night":"noon"));
+    ret.insert("guid",guid.toString().mid(1,36));
+    ret.insert("time",(night?sunset:sunrise).toUTC().toString(Qt::ISODate));
+    ret.insert("updateTime",QDateTime::currentDateTimeUtc().toString(Qt::ISODate));
+    ret.insert("createTime",ret.value("updateTime"));
+    ret.insert("dataSource",QString("uuid:%1").arg(WeatherApp::appUUID.toString().mid(1,36)));
+    ret.insert("source",QString::fromLocal8Bit(WeatherApp::appConfigKey));
+    layout.insert("type",QString("weatherPin"));
+    layout.insert("title",QString::fromLocal8Bit(gettext(night?"Sunset":"Sunrise")));
+    layout.insert("subtitle",QString("%1/%2").arg(fmtTmp(m_here.max_temp)).arg(fmtTmp(m_here.min_temp)));
+    layout.insert("body",night?m_here.night_text:m_here.day_text);
+    layout.insert("tinyIcon", night ? night_icon : day_icon);
+    layout.insert("largeIcon",layout.value("tinyIcon"));
+    layout.insert("locationName",QString::fromLocal8Bit(gettext("Current Location")));
+    foreach(const QString &city, m_locOrder) {
+        if(m_cities.contains(city)) {
+            hs.append("");
+            ps.append(WeatherApp::cityFcast.arg(city).arg(fmtTmp(m_cities.value(city).max_temp),fmtTmp(m_cities.value(city).min_temp)).arg(night?m_cities.value(city).night_text:m_cities.value(city).day_text));
+        }
+    }
+    if(!provider.isEmpty()) {
+        hs.append(QString::fromLocal8Bit(gettext("Provided by:")));
+        ps.append(provider);
+    }
+    layout.insert("headings",QJsonArray::fromStringList(hs));
+    layout.insert("paragraphs",QJsonArray::fromStringList(ps));
+    layout.insert("lastUpdated",ret.value("updateTime"));
+    ret.insert("layout",layout);
+    return ret;
+}
+
+const QString WeatherApp::cityFcast = "\u2014\n%1\n%2/%3, %4";
+const QUuid WeatherApp::currentLocationUUID = QUuid("5f63c159-1c67-455f-897e-125d70664c4f");
+const QUuid WeatherApp::appUUID = QUuid("61b22bc8-1e29-460d-a236-3fe409a439ff");
+const QByteArray WeatherApp::appConfigKey = QByteArray("weatherApp",10);
+/**
+ * @brief WeatherApp::WeatherApp Creates WeatherApp instance for given Pebble.
+ * @param pebble parent Pebble instance to provide BlobDB API.
+ * @param locations initial location list used to pre-populate locations which are supposed to be
+ * already stored in Pebble's BlobDB. Does not trigger Blob update, instead used to calculate
+ * whether update is required on consequent updates.
+ */
+WeatherApp::WeatherApp(Pebble *pebble, const QVariantList &locations) :
+    QObject(pebble),
+    m_pebble(pebble),
+    m_provider(nullptr)
+{
+    connect(m_pebble->blobdb(), &BlobDB::blobCommandResult, this, &WeatherApp::blobdbAckHandler);
+
+    setLocations(locations,false);
+}
+
+void WeatherApp::setProvider(WeatherProvider *provider)
+{
+    m_provider = provider;
+}
+
+/**
+ * @brief WeatherApp::updateForecasts repopulates forecasts into Timeline.
+ * @param fcstBuf list of forecasts, should be presented in correct order of days, from
+ * today to WeatherApp::m_fcstDays days after today. Pin is repopulated only if it
+ * does not equal to the one already cached in memory (eg. forecast changed).
+ * @param provider optional string which should reflect Weather Provider name
+ * (eg. "The Weather Channel")
+ */
+void WeatherApp::updateForecasts(const QList<Forecast> &fcstBuf, const QString &provider)
+{
+    for(int i=0;i<fcstBuf.size();i++) {
+        if(m_forecasts.size()>i && fcstBuf.at(i).equal(m_forecasts.at(i))) {
+            continue;
+        }
+        if(i>0 || fcstBuf.at(0).isValid())
+            m_pebble->insertPin(fcstBuf.at(i).getPin(i,false,provider));
+        m_pebble->insertPin(fcstBuf.at(i).getPin(i,true,provider));
+        if(m_forecasts.size()<=i) {
+            m_forecasts.append(fcstBuf.at(i));
+        } else {
+            m_forecasts.replace(i,fcstBuf.at(i));
+        }
+    }
+}
+
+QVariantList WeatherApp::getLocations() const
+{
+    QVariantList ret;
+    foreach(const QString &l, m_locOrder) {
+        QStringList city;
+        Location loc = m_locations.value(l);
+        city.append(loc.name);
+        city.append(loc.lat);
+        city.append(loc.lng);
+        ret.append(city);
+    }
+    return ret;
+}
+
+void WeatherApp::setLocations(const QVariantList &locs, bool push)
+{
+    qDebug() << "Entering locations" << locs << push;
+    if(locs.isEmpty()) {
+        m_locOrder.clear();
+        m_locations.clear();
+        if(push)
+            updateConfig();
+        return;
+    }
+    QStringList locOrder;
+    foreach(const QVariant &l, locs) {
+        Location loc;
+        QStringList city = l.toStringList();
+        if(city.length()<3) continue;
+        loc.name = city.at(0);
+        locOrder.append(loc.name);
+        if(l == locs.first())
+            loc.uuid = WeatherApp::currentLocationUUID;
+        else
+            loc.uuid = PlatformInterface::idToGuid(loc.name);
+        loc.lat = city.at(1);
+        loc.lng = city.at(2);
+        if(m_locations.contains(loc.name) && m_locations.value(loc.name) == loc)
+            continue;
+        m_locations.insert(loc.name,loc);
+        m_locUpdated = push;
+        qDebug() << "New location" << loc.name << loc.lat << loc.lng << loc.uuid;
+    }
+    if(m_locOrder != locOrder) {
+        qDebug() << "Locations updated" << m_locUpdated << "applying changes for" << locOrder;
+        m_locOrder = locOrder;
+        if(m_locUpdated) {
+            // Initiate full refresh
+            if(m_provider == nullptr)
+                emit requestUpdate();
+            else
+                m_provider->refreshWeather();
+        } else if(push) {
+            // Mere reorder, keep the data as is
+            for(int i=0;i<m_forecasts.size();i++) {
+                Forecast &f = m_forecasts[i];
+                f.reorder(locOrder);
+                if(f.isValid(i/2==1))
+                    m_pebble->insertPin(f.getPin(i/2,i%2==1));
+            }
+            m_locUpdated = true; // to allow update
+            updateConfig();
+        }
+    }
+}
+
+void WeatherApp::updateConfig()
+{
+    QList<QUuid> cfg;
+    if(!m_locUpdated) return;
+    foreach(const QString &l, m_locOrder) {
+        cfg.append(m_locations.value(l).uuid);
+    }
+    m_pebble->blobdb()->insert(BlobDB::BlobDBIdAppConfigs,WeatherConfigurations(cfg));
+    m_locUpdated = false;
+}
+
+void WeatherApp::injectObservation(const QString &l, const Observation &obs, bool force)
+{
+    if(m_locations.contains(l)) {
+        Location loc = m_locations.value(l);
+        if(force || !m_obss.contains(loc.uuid) || obs != m_obss.value(loc.uuid)) {
+            WeatherObservation wo(loc,obs);
+            qDebug() << "Updating observation data for" << l << wo.serialize().toHex();
+            m_pebble->blobdb()->insert(BlobDB::BlobDBIdWeatherData,wo);
+            m_obss.insert(loc.uuid,obs);
+        } else
+            qDebug() << "Ignoring observation data for" << l;
+    } else {
+        qWarning() << "Non-existing location" << l;
+    }
+}
+
+void WeatherApp::blobdbAckHandler(quint8 db, quint8 cmd, const QByteArray &key, quint8 ack)
+{
+    switch(db) {
+    case BlobDB::BlobDBIdAppConfigs:
+    case BlobDB::BlobDBIdWeatherData:
+        break;
+    default:
+        return;
+    }
+    if(db == BlobDB::BlobDBIdAppConfigs) {
+        if(key != appConfigKey) return;
+        if(cmd == BlobDB::OperationInsert) {
+            if(ack == BlobDB::StatusSuccess) {
+                emit locationsChanged();
+            } else
+                qDebug() << "Failed to save config" << ack;
+        }
+    } else {
+        if(ack != BlobDB::StatusSuccess)
+            qDebug() << "Failed to set forecast" << key.toHex() << ack;
+    }
+    qDebug() << "BlobDB response" << ((ack==BlobDB::StatusSuccess)?"ACK":"NACK") << ((cmd==BlobDB::OperationInsert)?"Insert":"Delete") << ((db==BlobDB::BlobDBIdAppConfigs)?"Locations":"Weather") << key.toHex();
+}

--- a/rockworkd/libpebble/weatherapp.h
+++ b/rockworkd/libpebble/weatherapp.h
@@ -1,0 +1,135 @@
+#ifndef WEATHERAPP_H
+#define WEATHERAPP_H
+
+#include <QObject>
+#include <QDateTime>
+#include <QStringList>
+#include <QHash>
+#include <QUuid>
+
+#include <limits.h>
+
+class Pebble;
+
+class WeatherProvider
+{
+public:
+    virtual void setUnits(const QChar &u) = 0;
+    virtual QChar getUnits() const = 0;
+    virtual void setLanguage(const QString &lang) = 0;
+    virtual void refreshWeather() = 0;
+};
+
+class WeatherApp : public QObject
+{
+    Q_OBJECT
+public:
+    static const QUuid currentLocationUUID;
+    static const QUuid appUUID;
+    static const QByteArray appConfigKey;
+    static const QString cityFcast;
+
+    WeatherApp(Pebble *pebble, const QVariantList &locations);
+
+    struct Location {
+        QString name;
+        QString lat;
+        QString lng;
+        QUuid uuid;
+        bool operator==(const Location &that) const {
+            return (uuid==currentLocationUUID)?(that.uuid==currentLocationUUID):(uuid == that.uuid && lat == that.lat && lng == that.lng);
+        }
+    };
+
+    class Observation {
+    public:
+        struct Data {
+            // 0 P Cloudy
+            // 1 Cloudy
+            // 2 L Snow
+            // 3 Rain
+            // 4 Shower
+            // 5 Snow
+            // 6 P Cloudy + L Rain
+            // 7 Sunny
+            // 8 Snow + Rain
+            int condition;
+            int temp_hi;
+            int temp_low;
+        };
+        Observation();
+        Observation(int tmp, const QString &text, const Data &today, const Data &tomorrow);
+        bool operator!=(const Observation &that) const;
+        bool operator==(const Observation &that) const;
+
+        int temp_now;
+        Data today;
+        Data tomorrow;
+        QDateTime timestamp;
+        QString text;
+    };
+
+    class Forecast {
+    public:
+        struct Data {
+            int min_temp = SHRT_MAX;
+            int max_temp = SHRT_MAX;
+            QString   day_text;
+            QString night_text;
+        };
+        Forecast(const QStringList &locOrder);
+        Forecast(const QStringList &locOrder, const Data &day, const QDateTime &sunrise, const QString &day_icon, const QDateTime &sunset, const QString &night_icon);
+
+        void initLoc(const Data &day, const QDateTime &sunrise, const QString &day_icon, const QDateTime &sunset, const QString &night_icon);
+        void addCity(const QString &name, const Data &day);
+        void reorder(const QStringList &newOrder);
+        QJsonObject getPin(int daynum, bool night=false, const QString &provider=QString()) const;
+        bool equal(const Forecast &that, int daypart=-1) const;
+        bool isValid(bool night=false) const;
+        bool isComplete() const;
+
+    private:
+        static QString fmtTmp(int tmp);
+
+        Data m_here;
+        QHash<QString,WeatherApp::Forecast::Data> m_cities;
+        QStringList m_locOrder;
+        QDateTime sunrise;
+        QDateTime sunset;
+        QString   day_icon;
+        QString night_icon;
+    };
+
+    void setProvider(WeatherProvider *provider);
+
+    QVariantList getLocations() const;
+    const QStringList & locOrder() const { return m_locOrder; }
+    Location getLocation(const QString &loc) const { return m_locations.value(loc); }
+    Location & location(const QString &loc) { return m_locations[loc]; }
+
+signals:
+    void locationChanged();
+    void locationsChanged();
+    void requestUpdate();
+
+public slots:
+    void updateConfig();
+    void setLocations(const QVariantList &locs, bool push=true);
+    void updateForecasts(const QList<Forecast> &fcstBuf, const QString &provider = QString());
+    void injectObservation(const QString &l, const Observation &obs, bool force=false);
+
+private slots:
+    void blobdbAckHandler(quint8 db, quint8 cmd, const QByteArray &key, quint8 ack);
+
+private:
+    QStringList m_locOrder;
+    QHash<QString,Location> m_locations;
+    bool m_locUpdated = false;
+    int m_fcstDays = 5;
+    QHash<QUuid,Observation> m_obss;
+    QList<Forecast> m_forecasts;
+    Pebble *m_pebble;
+    WeatherProvider *m_provider;
+};
+
+#endif // WEATHERAPP_H

--- a/rockworkd/libpebble/weatherapp.h
+++ b/rockworkd/libpebble/weatherapp.h
@@ -108,7 +108,6 @@ public:
     Location & location(const QString &loc) { return m_locations[loc]; }
 
 signals:
-    void locationChanged();
     void locationsChanged();
     void requestUpdate();
 

--- a/rockworkd/libpebble/weatherprovidertwc.cpp
+++ b/rockworkd/libpebble/weatherprovidertwc.cpp
@@ -1,0 +1,270 @@
+#include "weatherprovidertwc.h"
+
+#include "pebble.h"
+
+#include <QTimerEvent>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+#include <QGeoPositionInfoSource>
+#include <QGeoPositionInfo>
+
+
+const QString WeatherProviderTWC::urlTWC = "https://api.weather.com/v2/geocode/%1/aggregate.json?products=conditions,fcstdaily7&language=%2&units=%3&apiKey=%4";
+const QHash<QChar,QString> WeatherProviderTWC::code2units = {
+    {'a',""},//all
+    {'m',"metric"},
+    {'e',"imperial"},
+    {'h',"uk_hybrid"},
+    {'s',"metric_si"},
+};
+// Condition Codes suitable from Yahoo API https://developer.yahoo.com/weather/documentation.html
+const QHash<int,QString> WeatherProviderTWC::code2icon = {
+    // {4, "system://images/"}, - rain possible, t-storm
+    {11,"system://images/HEAVY_RAIN"},
+    {12,"system://images/HEAVY_RAIN"},
+    {13,"system://images/LIGHT_SNOW"}, // Snow flurries
+    {14,"system://images/LIGHT_SNOW"}, // Light Snow
+    {15,"system://images/HEAVY_SNOW"}, // Blowing Snow
+    {16,"system://images/HEAVY_SNOW"}, // Snow
+    {17,"system://images/HEAVY_RAIN"}, // Hail
+    {18,"system://images/RAINING_AND_SNOWING"}, // Sleet
+    //{}, // Dust, fog, haze, etc.
+    {26,"system://images/CLOUDY_DAY"}, // Clouds
+    {27,"system://images/CLOUDY_DAY"}, // M Cloudy N
+    {28,"system://images/CLOUDY_DAY"}, // M Cloudy D
+    {29,"system://images/PARTLY_CLOUDY"},
+    {30,"system://images/PARTLY_CLOUDY"},
+    {31,"system://images/TIMELINE_SUN"}, // Clear Night
+    {32,"system://images/TIMELINE_SUN"}, // Sunny Day
+    {33,"system://images/TIMELINE_SUN"}, // Mostly Clear N
+    {34,"system://images/TIMELINE_SUN"}, // Mostly Clear D
+    {35,"system://images/HEAVY_RAIN"}, // Rain and Hail
+    {36,"system://images/TIMELINE_SUN"}, // Hot
+    //{37} // Isolated Thunderstorms
+    {39,"system://images/LIGHT_RAIN"}, // Scattered T-Storms
+    {40,"system://images/LIGHT_RAIN"}, // Scattered showers
+    {45,"system://images/HEAVY_RAIN"}, // Thundershowers
+    {46,"system://images/HEAVY_SNOW"}, // Snow Showers
+    {47,"system://images/HEAVY_RAIN"} // Isolated Thundershowers
+};
+const QHash<int,int> code2code = {
+    {11,4},
+    {12,4},
+    {13,2},
+    {14,2},
+    {15,5},
+    {16,5},
+    {17,4},
+    {18,8},
+    {26,1},
+    {27,1},
+    {28,1},
+    {29,0},
+    {30,0},
+    {31,7},
+    {32,7},
+    {33,7},
+    {34,7},
+    {35,4},
+    {36,7},
+    {37,6},
+    {39,6},
+    {40,6},
+    {45,4},
+    {46,5},
+    {47,4}
+};
+
+WeatherProviderTWC::WeatherProviderTWC(Pebble *pebble, WeatherApp *weatherApp) :
+    QObject(pebble),
+    m_nam(pebble->nam()),
+    m_gps(nullptr),
+    m_pebble(pebble),
+    m_weatherApp(weatherApp)
+{
+    weatherApp->setProvider(this);
+}
+
+void WeatherProviderTWC::setApiKey(const QString &key)
+{
+    m_apiKey = key;
+    if(!m_apiKey.isEmpty()) {
+        startTimer(refreshInterval);
+        timerEvent(0);
+    }
+}
+
+void WeatherProviderTWC::setLanguage(const QString &lang)
+{
+    m_language = lang;
+    timerEvent(0);
+}
+
+QChar WeatherProviderTWC::getUnits() const
+{
+    return m_units;
+}
+void WeatherProviderTWC::setUnits(const QChar &u)
+{
+    m_units = u;
+}
+
+void WeatherProviderTWC::refreshWeather()
+{
+    timerEvent(0);
+}
+
+void WeatherProviderTWC::initGPS()
+{
+    if (!m_gps) {
+        m_gps = QGeoPositionInfoSource::createDefaultSource(this);
+
+        connect(m_gps, static_cast<void (QGeoPositionInfoSource::*)(QGeoPositionInfoSource::Error)>(&QGeoPositionInfoSource::error), this, &WeatherProviderTWC::gpsError);
+        connect(m_gps, &QGeoPositionInfoSource::positionUpdated, this, &WeatherProviderTWC::gotPosition);
+        connect(m_gps, &QGeoPositionInfoSource::updateTimeout, this, &WeatherProviderTWC::gpsTimeout);
+    }
+}
+
+void WeatherProviderTWC::timerEvent(QTimerEvent *e)
+{
+    if(m_apiKey.isEmpty() || m_weatherApp->locOrder().isEmpty()) {
+        if(m_apiKey.isEmpty() && e)
+            killTimer(e->timerId());
+        qDebug() << "API Key" << m_apiKey << "or Locations" << m_weatherApp->locOrder() << "are empty, ignoring update";
+        return;
+    }
+    initGPS();
+    QGeoPositionInfo gpi = m_gps->lastKnownPosition();
+    if(gpi.isValid() && gpi.timestamp().addSecs(60*61)>QDateTime::currentDateTimeUtc()) {
+        gotPosition(gpi);
+    } else {
+        m_gps->requestUpdate();
+    }
+}
+void WeatherProviderTWC::gotPosition(const QGeoPositionInfo &gpi)
+{
+    qDebug() << "Updating forecast for current location" << gpi.coordinate().latitude() << gpi.coordinate().longitude() << "with" << m_apiKey;
+    WeatherApp::Location &loc = m_weatherApp->location(m_weatherApp->locOrder().first());
+    loc.lat = QString::number(gpi.coordinate().latitude());
+    loc.lng = QString::number(gpi.coordinate().longitude());
+    if(!m_apiKey.isEmpty())
+        updateForecast();
+}
+
+void WeatherProviderTWC::gpsError(int err)
+{
+    qWarning() << "Error getting location data" << err;
+}
+
+void WeatherProviderTWC::gpsTimeout()
+{
+    qWarning() << "Timeout getting location data";
+}
+
+WeatherApp::Observation WeatherProviderTWC::parseObs(const QJsonObject &obj, const QJsonArray &days)
+{
+    QString text = obj.value("phrase_12char").toString();
+    if(text.isEmpty())
+        text = obj.value("phrase_22char").toString();
+    if(text.isEmpty())
+        text = obj.value("phrase_32char").toString();
+    return WeatherApp::Observation(obj.value(code2units.value(m_units)).toObject().value("temp").toInt(SHRT_MAX),text,
+    {code2code.value(obj.value("icon_code").toInt()),
+     days.at(0).toObject().value("max_temp").toInt(SHRT_MAX),days.at(0).toObject().value("min_temp").toInt(SHRT_MAX)},
+    {code2code.value(days.at(1).toObject().contains("day")?days.at(1).toObject().value("day").toObject().value("icon_code").toInt():days.at(1).toObject().value("night").toObject().value("icon_code").toInt()),
+     days.at(1).toObject().value("max_temp").toInt(SHRT_MAX),days.at(1).toObject().value("min_temp").toInt(SHRT_MAX)});
+}
+
+WeatherApp::Forecast::Data WeatherProviderTWC::parseDay(const QJsonObject &day)
+{
+    WeatherApp::Forecast::Data data;
+    data.min_temp = day.value("min_temp").toInt(SHRT_MAX);
+    data.max_temp = day.value("max_temp").toInt(SHRT_MAX);
+    if(day.contains("day"))
+        data.day_text = day.value("day").toObject().value("narrative").toString();
+    if(day.contains("night"))
+        data.night_text = day.value("night").toObject().value("narrative").toString();
+    return data;
+}
+void WeatherProviderTWC::parseLoc(WeatherApp::Forecast &loc, const QJsonObject &day)
+{
+    QDateTime sunset = day.value("sunset").toVariant().toDateTime(),
+             sunrise = day.value("sunrise").toVariant().toDateTime();
+    QString day_icon, night_icon;
+    if(day.contains("day"))
+        day_icon = code2icon.value(day.value("day").toObject().value("icon_code").toInt(),"system://images/TIMELINE_WEATHER");
+    if(day.contains("night"))
+        night_icon = code2icon.value(day.value("night").toObject().value("icon_code").toInt(),"system://images/TIMELINE_WEATHER");
+    loc.initLoc(parseDay(day),sunrise,day_icon,sunset,night_icon);
+}
+
+void WeatherProviderTWC::updateForecast()
+{
+    foreach(const QString &l, m_weatherApp->locOrder()) {
+        WeatherApp::Location loc = m_weatherApp->getLocation(l);
+        if(code2units.value(m_units).isEmpty()) {
+            qWarning() << "Cannot translate units" << m_units << "into container";
+            return;
+        }
+        QUrl twc(urlTWC.arg(loc.lat+"/"+loc.lng).arg(m_language,m_units).arg(m_apiKey));
+        QNetworkRequest req(twc);
+        QNetworkReply *rpl = m_nam->get(req);
+        qDebug() << "Fetching weather data for" << l << "from" << twc;
+        connect(rpl,&QNetworkReply::finished, [this,l,rpl](){
+            rpl->deleteLater();
+            QByteArray reply = rpl->readAll();
+            //qDebug() << reply;
+            if(rpl->error() == QNetworkReply::NoError) {
+                QJsonParseError jpe;
+                QJsonDocument json = QJsonDocument::fromJson(reply,&jpe);
+                if(jpe.error == QJsonParseError::NoError && json.isObject()) {
+                    QJsonObject obj = json.object();
+                    if(obj.contains("conditions") && !obj.value("conditions").toObject().value("errors").toBool() \
+                            && obj.contains("fcstdaily7") && !obj.value("fcstdaily7").toObject().value("errors").toBool())
+                    {
+                        QJsonArray days = obj.value("fcstdaily7").toObject().value("data").toObject().value("forecasts").toArray();
+                        qDebug() << "Updating current conditions for" << l;
+                        // Update current conditions for all locations
+                        m_weatherApp->injectObservation(l,parseObs(obj.value("conditions").toObject().value("data").toObject().value("observation").toObject(),days));
+                        qDebug() << "Collecting forecast data for" << m_fcstDays << "days";
+                        // Collect forecasts for all locations
+                        for(int i=0;i<qMin(days.size(),m_fcstDays);i++) {
+                            if(m_fcstsBuff.size()==i) {
+                                m_fcstsBuff.append(WeatherApp::Forecast(m_weatherApp->locOrder()));
+                            }
+                            if(l == m_weatherApp->locOrder().first()) {
+                                parseLoc(m_fcstsBuff[i],days[i].toObject());
+                            } else {
+                                m_fcstsBuff[i].addCity(l,parseDay(days[i].toObject()));
+                            }
+                        }
+                        // On last iteration - check if anything needs to be updated in the pebble
+                        if(m_fcstsBuff.first().isComplete()) {
+                            m_weatherApp->updateConfig();
+                            // Update and repopulate pins from shadow buffer
+                            qDebug() << "Parsing" << m_fcstsBuff.size() << "forecasts";
+                            m_weatherApp->updateForecasts(m_fcstsBuff,"The Weather Channel");
+                            m_fcstsBuff.clear();
+                        }
+                        return;
+                    } else if(obj.contains("errors") && obj.value("errors").toArray().size()>0) {
+                        qWarning() << "Error in TWC transaction" << obj.value("errors").toArray().at(0).toObject().value("error").toObject().value("message");
+                    } else {
+                        qWarning() << "Unknown TWC reply" << json.toJson();
+                    }
+                } else {
+                    qWarning() << "Error parsing TWC response" << jpe.errorString();
+                }
+            } else if(rpl->error() == QNetworkReply::AuthenticationRequiredError) {
+                m_apiKey.clear();
+                qWarning() << "Wrong TWC API key" << rpl->errorString();
+            } else {
+                qWarning() << "Error fetching TWC data" << rpl->errorString();
+            }
+        });
+    }
+}

--- a/rockworkd/libpebble/weatherprovidertwc.h
+++ b/rockworkd/libpebble/weatherprovidertwc.h
@@ -1,0 +1,59 @@
+#ifndef WEATHERPROVIDERTWC_H
+#define WEATHERPROVIDERTWC_H
+
+#include "weatherapp.h"
+
+class QNetworkAccessManager;
+class QGeoPositionInfoSource;
+class QGeoPositionInfo;
+class QJsonObject;
+
+class WeatherProviderTWC : public QObject, public WeatherProvider
+{
+    Q_OBJECT
+public:
+    static const quint32 refreshInterval = 60 * 60 * 1000;
+    static const QString urlTWC;
+    static const QHash<QChar,QString> code2units;
+    static const QHash<int,QString> code2icon;
+
+    WeatherProviderTWC(Pebble *pebble, WeatherApp *weatherApp);
+
+    QChar getUnits() const;
+    WeatherApp::Observation parseObs(const QJsonObject &obj, const QJsonArray &days);
+    static WeatherApp::Forecast::Data parseDay(const QJsonObject &day);
+    static void parseLoc(WeatherApp::Forecast &loc, const QJsonObject &day);
+
+signals:
+
+public slots:
+    void setUnits(const QChar &u);
+    void setApiKey(const QString &key);
+    void setLanguage(const QString &lang);
+    void refreshWeather();
+
+protected slots:
+    void timerEvent(QTimerEvent *) override;
+
+private slots:
+    void updateForecast();
+    void initGPS();
+    void gpsError(int);
+    void gpsTimeout();
+    void gotPosition(const QGeoPositionInfo &gpi);
+
+private:
+    bool m_locUpdated = false;
+    int m_fcstDays = 5;
+    QList<WeatherApp::Forecast> m_fcstsBuff;
+    QString m_language = "en-US";
+    QChar m_units = 'm';
+
+    QString m_apiKey;
+    QNetworkAccessManager *m_nam;
+    QGeoPositionInfoSource *m_gps;
+    Pebble *m_pebble;
+    WeatherApp *m_weatherApp;
+};
+
+#endif // WEATHERPROVIDERTWC_H

--- a/rockworkd/libpebble/weatherprovidertwc.h
+++ b/rockworkd/libpebble/weatherprovidertwc.h
@@ -3,6 +3,8 @@
 
 #include "weatherapp.h"
 
+class WatchConnection;
+
 class QNetworkAccessManager;
 class QGeoPositionInfoSource;
 class QGeoPositionInfo;
@@ -17,7 +19,7 @@ public:
     static const QHash<QChar,QString> code2units;
     static const QHash<int,QString> code2icon;
 
-    WeatherProviderTWC(Pebble *pebble, WeatherApp *weatherApp);
+    WeatherProviderTWC(Pebble *pebble, WatchConnection *conneciton, WeatherApp *weatherApp);
 
     QChar getUnits() const;
     WeatherApp::Observation parseObs(const QJsonObject &obj, const QJsonArray &days);
@@ -42,7 +44,10 @@ private slots:
     void gpsTimeout();
     void gotPosition(const QGeoPositionInfo &gpi);
 
+    void watchConnected();
+
 private:
+    bool m_updateMissed = false;
     bool m_locUpdated = false;
     int m_fcstDays = 5;
     QList<WeatherApp::Forecast> m_fcstsBuff;
@@ -53,6 +58,7 @@ private:
     QNetworkAccessManager *m_nam;
     QGeoPositionInfoSource *m_gps;
     Pebble *m_pebble;
+    WatchConnection *m_connection;
     WeatherApp *m_weatherApp;
 };
 

--- a/rockworkd/platformintegration/sailfish/sailfishplatform.cpp
+++ b/rockworkd/platformintegration/sailfish/sailfishplatform.cpp
@@ -271,7 +271,7 @@ void SailfishPlatform::stopOrganizer() const
 void SailfishPlatform::sendTextMessage(const QString &contact, const QString &text) const
 {
     qDebug() << "Sending text message for" << contact << text;
-    telepathyResponse("/org/freedesktop/Telepathy/Account/ring/tel/account0",contact,text);
+    telepathyResponse("/org/freedesktop/Telepathy/Account/ring/tel/ril_0",contact,text);
 }
 
 void SailfishPlatform::telepathyResponse(const QString &account, const QString &contact, const QString &text) const

--- a/rockworkd/rockworkd.pro
+++ b/rockworkd/rockworkd.pro
@@ -51,6 +51,7 @@ SOURCES += main.cpp \
     libpebble/appmanager.cpp \
     libpebble/appmsgmanager.cpp \
     libpebble/uploadmanager.cpp \
+    libpebble/sendtextapp.cpp \
     libpebble/bluez/bluezclient.cpp \
     libpebble/bluez/bluez_agentmanager1.cpp \
     libpebble/bluez/bluez_adapter1.cpp \
@@ -109,6 +110,7 @@ HEADERS += \
     libpebble/appmanager.h \
     libpebble/appmsgmanager.h \
     libpebble/uploadmanager.h \
+    libpebble/sendtextapp.h \
     libpebble/bluez/bluezclient.h \
     libpebble/bluez/bluez_agentmanager1.h \
     libpebble/bluez/bluez_adapter1.h \

--- a/rockworkd/rockworkd.pro
+++ b/rockworkd/rockworkd.pro
@@ -51,6 +51,8 @@ SOURCES += main.cpp \
     libpebble/appmanager.cpp \
     libpebble/appmsgmanager.cpp \
     libpebble/uploadmanager.cpp \
+    libpebble/weatherapp.cpp \
+    libpebble/weatherprovidertwc.cpp \
     libpebble/sendtextapp.cpp \
     libpebble/bluez/bluezclient.cpp \
     libpebble/bluez/bluez_agentmanager1.cpp \
@@ -110,6 +112,8 @@ HEADERS += \
     libpebble/appmanager.h \
     libpebble/appmsgmanager.h \
     libpebble/uploadmanager.h \
+    libpebble/weatherapp.h \
+    libpebble/weatherprovidertwc.h \
     libpebble/sendtextapp.h \
     libpebble/bluez/bluezclient.h \
     libpebble/bluez/bluez_agentmanager1.h \


### PR DESCRIPTION
This one has just TWC as a reference implementation. The reason is - to implement any other provider I need to use some non-trivial steps to collate and pull together all the required elements, while TWC looks like one of those "custom offerings" where returned data is specifically tailored for the needs. I.e. need just to parse and s.upload the data.

Send text is really simple and actually reuses most of the existing libpebble elements from new timeline - canned messages and attributes. Just a simple new container for contacts, and a wrapper for canned messages to store in blobs.

No GUI, mere DBus.