### PR TITLE
Send Text GUI Settings and some fixes

### DIFF
--- a/rockwork/pebble.h
+++ b/rockwork/pebble.h
@@ -101,7 +101,10 @@ public:
     QVariantMap notificationsFilter() const;
 
 public slots:
+    QVariantMap getCannedResponses(const QStringList &keys);
     void setCannedResponses(const QVariantMap &cans);
+    QVariantMap getCannedContacts(const QStringList &keys);
+    void setCannedContacts(const QVariantMap &cans);
     void setNotificationFilter(const QString &sourceId, int enabled);
     void forgetNotificationFilter(const QString &sourceId);
     void removeApp(const QString &uuid);
@@ -155,7 +158,8 @@ signals:
 
 private:
     QVariant fetchProperty(const QString &propertyName) const;
-    QVariantMap fetchVarMap(const QString &propertyName) const;
+    void sendVarMap(const QString &property, const QVariantMap &values);
+    QVariantMap fetchVarMap(const QString &propertyName, const QStringList *keys = 0) const;
 
 private slots:
     void dataChanged();

--- a/rockwork/qml/pages/InstalledAppsPage.qml
+++ b/rockwork/qml/pages/InstalledAppsPage.qml
@@ -78,10 +78,10 @@ Page {
             };
         } else if(uuid === "{0863fc6a-66c5-4f62-ab8a-82ed00a98b5d}") {
             popup = pageStack.push(Qt.resolvedUrl("SendTextSettingsDialog.qml"), {
-                                            params: pebble.sendTextParams
+                                            pebble: pebble
                                         },PageStackAction.Immediate);
             cbacc = function () {
-                pebble.sendTextParams = popup.params
+                pebble.setCannedContacts(popup.contacts)
             };
         }
         if(popup && cbacc) {

--- a/rockwork/qml/pages/SendTextSettingsDialog.qml
+++ b/rockwork/qml/pages/SendTextSettingsDialog.qml
@@ -1,42 +1,199 @@
 import QtQuick 2.2
 import Sailfish.Silica 1.0
+import Sailfish.Contacts 1.0
+import Sailfish.Telephony 1.0
+import org.nemomobile.contacts 1.0
 
 Dialog {
     id: root
 
-    property var params: null
-    property var contacts: []
+    property var pebble: null
+    property var contacts: {}
+    property var newCtx: {}
+    property string msgKey: "com.pebble.sendText"
+    property string modem: "/ril_0"
+    property string telePhone: "/org/freedesktop/Telepathy/Account/ring/tel"
     canAccept: false
 
-    Column {
-        width: parent.width
-
-        DialogHeader {
-            title: qsTr("Messaging Settings")
-            defaultAcceptText: qsTr("OK")
-            defaultCancelText: qsTr("Cancel")
-        }
-
-        SectionHeader {
-            text: qsTr("Contacts")
-        }
-        Label {
+    SilicaFlickable {
+        anchors.fill: parent
+        contentHeight: content.height
+        Column {
+            id: content
             width: parent.width
-            text: "Not implemented yet"
-        }
 
-        SectionHeader {
-            text: qsTr("Messages")
+            DialogHeader {
+                title: qsTr("Messaging Settings")
+                defaultAcceptText: qsTr("OK")
+                defaultCancelText: qsTr("Cancel")
+            }
+
+            SectionHeader {
+                text: qsTr("Contacts")
+            }
+            ListModel {
+                id: oldModel
+                property var src: {}
+            }
+
+            SilicaListView {
+                id: oldContacts
+                model: oldModel
+                width: parent.width
+                height: contentItem.childrenRect.height
+                delegate: ListItem {
+                    id: liCtx
+                    width: oldContacts.width
+                    contentHeight: Theme.itemSizeSmall
+                    height: contentHeight
+                    Row {
+                        width: parent.width
+                        height: parent.contentHeight
+                        Label {
+                            id: lblType
+                            text: model.type
+                            width: Theme.iconSizeMedium+Theme.paddingSmall
+                            anchors.verticalCenter: parent.verticalCenter
+                        }
+                        Column {
+                            width: parent.width - lblType.width - btnDel.width
+                            Label {
+                                id: lblName
+                                text: model.name
+                                anchors.left: parent.left
+                            }
+                            Label {
+                                id: lblNum
+                                text: model.uri
+                                anchors.right: parent.right
+                                font.pixelSize: Theme.fontSizeTiny
+                            }
+                        }
+                        IconButton {
+                            id: btnDel
+                            //anchors.right: parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            icon.source: "image://theme/icon-m-remove"
+                            onClicked: liCtx.remorseAction(qsTr("Really Delete?"),function(){
+                                if(oldModel.src[model.name].length>1) {
+                                    oldModel.src[model.name].splice(oldModel.src[model.name].indexOf(model.num),1);
+                                } else {
+                                    delete oldModel.src[model.name];
+                                }
+                                oldModel.remove(model.index);
+                                root.canAccept=true;
+                            })
+                        }
+                    }
+                    ListView.onRemove: animateRemoval(liCtx)
+                    Separator {
+                        width: parent.width
+                        color: Theme.highlightColor
+                        height: 1
+                        anchors.bottom: parent.bottom
+                    }
+                }
+            }
+
+            RecipientField {
+                id: newContacts
+                width: parent.width
+                //multipleAllowed: false
+                requiredProperty: (PeopleModel.AccountUriRequired | PeopleModel.PhoneNumberRequired )
+                showLabel: false
+                onLastFieldExited: {
+                    console.log("Last",selectedContacts)
+                }
+                onSelectionChanged: {
+                    console.log("Selection",focus)
+                    updateContacts();
+                }
+                function updateContacts() {
+                    root.newCtx = {};
+                    for(var i=0;i<selectedContacts.count;i++) {
+                        var item = selectedContacts.get(i);
+                        if(!item || !item.person) break;
+                        var name = item.person.displayLabel;
+                        var value = ((item.propertyType==="accountUri")?item.property['path']+":"+item.property['uri']:root.telePhone+root.modem+":"+item.property['number']);
+                        if(!(name in root.newCtx)) {
+                            root.newCtx[name] = [];
+                        }
+                        root.newCtx[name].push(value);
+                        console.log("Contact",item.person.id,name,item.propertyType,newCtx[name]);
+                    }
+                    console.log("Updated",typeof root.newCtx,Object.keys(root.newCtx).length);
+                    root.canAccept = (root.canAccept || (typeof root.newCtx === 'object' && Object.keys(root.newCtx).length > 0));
+                }
+            }
+
+            SectionHeader {
+                text: qsTr("Pick SIM for new contacts")
+                visible: simSelector.visible
+            }
+            SimSelector {
+                id: simSelector
+                visible: modemManager.modemSimModel.count>1
+                updateSelectedSim: false
+                onSimSelected: {
+                    console.log("SIM",modemPath);
+                    root.modem = modemPath;
+                }
+            }
+
+            SectionHeader {
+                text: qsTr("Messages")
+            }
+            Button {
+                text: qsTr("Edit Messages")
+                width: parent.width
+                onClicked: {
+                    pageStack.push(Qt.resolvedUrl("ResponsesPage.qml"), {
+                                       pebble: pebble,
+                                       source: msgKey,
+                                       title: qsTr("Send Text Messages"),
+                                       list: pebble.getCannedResponses([msgKey])[msgKey]})
+                }
+
+            }
         }
-        Label {
-            width: parent.width
-            text: "Not implemented yet"
+    }
+
+    Component.onCompleted: {
+        oldModel.src = pebble.getCannedContacts([]);
+        root.modem = simSelector.activeModem;
+        for(var i in oldModel.src) {
+            var can = oldModel.src[i];
+            console.log("Contact",i,can);
+            for(var j=0;j<can.length;j++) {
+                var type = "SIM1";
+                var uri = can[j];
+                var el = uri.split(':');
+                console.log("Number",type,uri,el);
+                if(el.length>1) {
+                    uri=el[1];
+                    var pe = el[0].split("/");
+                    if(pe.length > 7 && pe[7].substr(0,4) === "ril_") {
+                        type="SIM"+(parseInt(pe[7].split('_')[1])+1);
+                    } else {
+                        type="IM";
+                    }
+                }
+                oldModel.append({"type":type,"name":i,"uri":uri,"num":can[j]});
+            }
         }
     }
 
     onDone: {
         if(result === DialogResult.Accepted) {
-            root.params["contacts"] = contacts;
+            contacts = oldModel.src;
+            for(var name in newCtx) {
+                if(name in contacts) {
+                    contacts[name] = contacts[name].concat(newCtx[name]);
+                } else {
+                    contacts[name] = newCtx[name];
+                }
+                console.log("Adding",name,contacts[name]);
+            }
         }
     }
 }

--- a/rockwork/translations/rockpool.ts
+++ b/rockwork/translations/rockpool.ts
@@ -855,28 +855,48 @@
 <context>
     <name>SendTextSettingsDialog</name>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="15"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="26"/>
         <source>Messaging Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="16"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="27"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="17"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="28"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="21"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="32"/>
         <source>Contacts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="29"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="77"/>
+        <source>Really Delete?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="130"/>
+        <source>Pick SIM for new contacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="144"/>
         <source>Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="147"/>
+        <source>Edit Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="153"/>
+        <source>Send Text Messages</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/rockwork/translations/rockpool_de.ts
+++ b/rockwork/translations/rockpool_de.ts
@@ -855,29 +855,49 @@
 <context>
     <name>SendTextSettingsDialog</name>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="15"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="26"/>
         <source>Messaging Settings</source>
-        <translation>Nachrichteneinstellungen</translation>
+        <translation>Nachrichten Einstellen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="16"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="27"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="17"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="28"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="21"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="32"/>
         <source>Contacts</source>
         <translation>Kontakte</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="29"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="77"/>
+        <source>Really Delete?</source>
+        <translation>Wirklich löschen?</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="130"/>
+        <source>Pick SIM for new contacts</source>
+        <translation>Wähle SIM für neue Kontakte</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="144"/>
         <source>Messages</source>
         <translation>Mitteilungen</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="147"/>
+        <source>Edit Messages</source>
+        <translation>Meldungen Bearbeiten</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="153"/>
+        <source>Send Text Messages</source>
+        <translation>Kurznachricht Senden</translation>
     </message>
 </context>
 <context>

--- a/rockwork/translations/rockpool_fr.ts
+++ b/rockwork/translations/rockpool_fr.ts
@@ -855,28 +855,48 @@
 <context>
     <name>SendTextSettingsDialog</name>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="15"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="26"/>
         <source>Messaging Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="16"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="27"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="17"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="28"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="21"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="32"/>
         <source>Contacts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="29"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="77"/>
+        <source>Really Delete?</source>
+        <translation type="unfinished">Confirmer suppression</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="130"/>
+        <source>Pick SIM for new contacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="144"/>
         <source>Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="147"/>
+        <source>Edit Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="153"/>
+        <source>Send Text Messages</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/rockwork/translations/rockpool_nl.ts
+++ b/rockwork/translations/rockpool_nl.ts
@@ -855,28 +855,48 @@
 <context>
     <name>SendTextSettingsDialog</name>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="15"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="26"/>
         <source>Messaging Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="16"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="27"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="17"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="28"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="21"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="32"/>
         <source>Contacts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="29"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="77"/>
+        <source>Really Delete?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="130"/>
+        <source>Pick SIM for new contacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="144"/>
         <source>Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="147"/>
+        <source>Edit Messages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="153"/>
+        <source>Send Text Messages</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/rockwork/translations/rockpool_ru.ts
+++ b/rockwork/translations/rockpool_ru.ts
@@ -857,29 +857,49 @@
 <context>
     <name>SendTextSettingsDialog</name>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="15"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="26"/>
         <source>Messaging Settings</source>
         <translation>Настройки Сообщений</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="16"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="27"/>
         <source>OK</source>
         <translation>Принять</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="17"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="28"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="21"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="32"/>
         <source>Contacts</source>
         <translation>Контакты</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="29"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="77"/>
+        <source>Really Delete?</source>
+        <translation>Действительно Удалить?</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="130"/>
+        <source>Pick SIM for new contacts</source>
+        <translation>Выбрать СИМ для новых контактов</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="144"/>
         <source>Messages</source>
         <translation>Сообщения</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="147"/>
+        <source>Edit Messages</source>
+        <translation>Редактировать Сообщения</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="153"/>
+        <source>Send Text Messages</source>
+        <translation>Текстовые Сообщения</translation>
     </message>
 </context>
 <context>

--- a/rockwork/translations/rockpool_uk.ts
+++ b/rockwork/translations/rockpool_uk.ts
@@ -856,29 +856,49 @@
 <context>
     <name>SendTextSettingsDialog</name>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="15"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="26"/>
         <source>Messaging Settings</source>
         <translation>Повідомлення</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="16"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="27"/>
         <source>OK</source>
         <translation>Добре</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="17"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="28"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="21"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="32"/>
         <source>Contacts</source>
         <translation>Контакти</translation>
     </message>
     <message>
-        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="29"/>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="77"/>
+        <source>Really Delete?</source>
+        <translation>Дійсно Видалити?</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="130"/>
+        <source>Pick SIM for new contacts</source>
+        <translation>Вкажіть СІМ для нових контактів</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="144"/>
         <source>Messages</source>
         <translation>Повідомлення</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="147"/>
+        <source>Edit Messages</source>
+        <translation>Правити Повідомлення</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SendTextSettingsDialog.qml" line="153"/>
+        <source>Send Text Messages</source>
+        <translation>Текстові Повідомлення</translation>
     </message>
 </context>
 <context>

--- a/rockworkd/dbusinterface.cpp
+++ b/rockworkd/dbusinterface.cpp
@@ -113,7 +113,7 @@ QVariantMap DBusPebble::getCannedResponses(const QStringList &groups) const
  */
 void DBusPebble::setFavoriteContacts(const QVariantMap &cans)
 {
-    QHash<QString,QStringList> ctxs;
+    QMap<QString,QStringList> ctxs;
     foreach(const QString &key, cans.keys()) {
         ctxs.insert(key,cans.value(key).toStringList());
     }
@@ -121,7 +121,7 @@ void DBusPebble::setFavoriteContacts(const QVariantMap &cans)
 }
 QVariantMap DBusPebble::getFavoriteContacts(const QStringList &names) const
 {
-    QHash<QString,QStringList> cans = m_pebble->getCannedContacts(names);
+    QMap<QString,QStringList> cans = m_pebble->getCannedContacts(names);
     QVariantMap ret;
     foreach(const QString &key,cans.keys()) {
         ret.insert(key,QVariant::fromValue(cans.value(key)));

--- a/rockworkd/libpebble/devconnection.h
+++ b/rockworkd/libpebble/devconnection.h
@@ -39,15 +39,16 @@ public slots:
 
     void onWatchConnected();
     void sendToWatch(const QByteArray &msg);
-    void installBundle(QString file);
+    void installBundle(const QString &file);
     void onWatchDisconnected();
     void onRawIncomingMsg(const QByteArray &msg);
     void onRawOutgoingMsg(const QByteArray &msg);
 private slots:
     void socketConnected();
     void socketDisconnected();
-    void textDataReceived(QString msg);
-    void rawDataReceived(QByteArray data);
+    void textDataReceived(const QString &msg);
+    void rawDataReceived(const QByteArray &data);
+    void handleMessage(const QByteArray &data);
     void broadcast(const QByteArray &msg);
 private:
     QList<QWebSocket *> m_clients;
@@ -85,7 +86,7 @@ public:
     virtual bool isRequest() const = 0;
     virtual bool isReply() const = 0;
     virtual void execute() = 0;
-    static DevPacket * CreatePacket(QByteArray &data, QWebSocket *sock, DevConnection *srv);
+    static DevPacket * CreatePacket(const QByteArray &data, QWebSocket *sock, DevConnection *srv);
     virtual ~DevPacket() = default;
 signals:
     void complete();
@@ -94,8 +95,8 @@ private slots:
     void serverDown();
 
 protected:
-    DevPacket(QByteArray &data, QWebSocket *sock, DevConnection *srv);
-    QByteArray &m_data;
+    DevPacket(const QByteArray &data, QWebSocket *sock, DevConnection *srv);
+    QByteArray m_data;
     QWebSocket *m_sock;
     DevConnection *m_srv;
 };

--- a/rockworkd/libpebble/pebble.h
+++ b/rockworkd/libpebble/pebble.h
@@ -100,8 +100,8 @@ public:
     QVariantMap cannedMessages() const;
     void setCannedMessages(const QVariantMap &cans) const;
     QHash<QString,QStringList> getCannedMessages(const QStringList &groups = QStringList()) const;
-    void setCannedContacts(const QHash<QString,QStringList> &cans);
-    QHash<QString,QStringList> getCannedContacts(const QStringList &names = QStringList()) const;
+    void setCannedContacts(const QMap<QString,QStringList> &cans, bool push=true);
+    QMap<QString,QStringList> getCannedContacts(const QStringList &names = QStringList()) const;
     qint32 timelineWindowStart() const;
     qint32 timelineWindowFade() const;
     qint32 timelineWindowEnd() const;

--- a/rockworkd/libpebble/platforminterface.h
+++ b/rockworkd/libpebble/platforminterface.h
@@ -38,7 +38,7 @@ public:
     virtual void removeNotification(const QUuid &uuid) const = 0;
     virtual const QHash<QString,QStringList>& cannedResponses() const = 0;
     virtual void setCannedResponses(const QHash<QString,QStringList> &cans) = 0;
-    virtual void sendTextMessage(const QString &contact, const QString &text) const = 0;
+    virtual void sendTextMessage(const QString &account, const QString &contact, const QString &text) const = 0;
 signals:
     void newTimelinePin(const QJsonObject &pin);
 

--- a/rockworkd/libpebble/sendtextapp.h
+++ b/rockworkd/libpebble/sendtextapp.h
@@ -33,11 +33,13 @@ public:
 signals:
     void messageBlobSet(const QByteArray &key);
     void contactBlobSet();
+    void sendTextMessage(const QString &account, const QString &contact, const QString &text) const;
 
 public slots:
+    void handleTextAction(const QString &contact, const QString &text) const;
     void setCannedMessages(const QHash<QString,QStringList> &cans);
     void wipeCannedMessages();
-    void setCannedContacts(const QList<Contact> &favs);
+    void setCannedContacts(const QList<Contact> &favs, bool push=true);
     void wipeContacts();
 
 private slots:
@@ -45,6 +47,7 @@ private slots:
 
 private:
     QHash<QByteArray,QStringList> m_messages;
+    QHash<QString,QString> m_revLookup;
     QList<Contact> m_contacts;
 
     Pebble *m_pebble;

--- a/rockworkd/libpebble/watchconnection.h
+++ b/rockworkd/libpebble/watchconnection.h
@@ -55,7 +55,7 @@ public:
         EndpointLogDump = 2002,
 //        EndpointWatchReset = 2003,
 //        EndpointWatchApp = 2004,
-//        EndpointAppLogs = 2006,
+        EndpointAppLogs = 2006,
         EndpointNotification = 3000,
 //        watchEXTENSIBLE_NOTIFS = 3010, // Deprecated in 3.x
 //        watchRESOURCE = 4000,

--- a/rockworkd/platformintegration/sailfish/sailfishplatform.cpp
+++ b/rockworkd/platformintegration/sailfish/sailfishplatform.cpp
@@ -268,15 +268,18 @@ void SailfishPlatform::stopOrganizer() const
     m_organizerAdapter->disable();
 }
 
-void SailfishPlatform::sendTextMessage(const QString &contact, const QString &text) const
+void SailfishPlatform::sendTextMessage(const QString &account, const QString &contact, const QString &text) const
 {
     qDebug() << "Sending text message for" << contact << text;
-    telepathyResponse("/org/freedesktop/Telepathy/Account/ring/tel/ril_0",contact,text);
+    if(account.isEmpty() || account.startsWith("/org/freedesktop/Telepathy/Account/"))
+        telepathyResponse(account,contact,text);
+    else
+        qWarning() << "No handler to send message from" << account << "to" << contact << "with" << text;
 }
 
 void SailfishPlatform::telepathyResponse(const QString &account, const QString &contact, const QString &text) const
 {
-    QDBusObjectPath acct(account);
+    QDBusObjectPath acct(account.isEmpty()?"/org/freedesktop/Telepathy/Account/ring/tel/ril_0":account);
     QVariantMap arg1,arg2;
     arg1.insert("message-type",0);
     arg2.insert("content-type",QString("text/plain"));
@@ -292,7 +295,7 @@ void SailfishPlatform::telepathyResponse(const QString &account, const QString &
         } else
             qDebug() << "Sent message under uuid" << res.value();
     } else {
-        qWarning() << res.error().message();
+        qWarning() << acct.path() << res.error().message();
     }
 }
 

--- a/rockworkd/platformintegration/sailfish/sailfishplatform.h
+++ b/rockworkd/platformintegration/sailfish/sailfishplatform.h
@@ -43,7 +43,7 @@ public:
 
     const QHash<QString,QStringList>& cannedResponses() const override;
     void setCannedResponses(const QHash<QString, QStringList> &cans) override;
-    void sendTextMessage(const QString &contact, const QString &text) const override;
+    void sendTextMessage(const QString &account, const QString &contact, const QString &text) const override;
 
 public slots:
     void newNotificationPin(watchfish::Notification *notification);


### PR DESCRIPTION
Apart from GUI for Send Text App following changes in service:
* Send Text is now (sender)account agnostic, Send Text app could add both IM or Phone contacts. That also creates possibility to add other than Telepathy TextMsg _drivers_. And of course that answers multisim question - Phone contacts just needs full path to the proper modem Telepathy account.
* A small fix for Send Text settings (to clean up removed entries) and contact order - QHash was used which resulted random contact order. That is now replaced by Map to have Alphabetic order.
* Non-related small addition with WatchAppLog handler. Ultimately one can see those logs using pebble SDK logs command via DevCon. Now DevConn will parse them on its own, but only when there are no pebble SDK clients connected.