### PR TITLE
Log severity, new platforms, old fixes

### DIFF
--- a/rockwork/qml/pages/DeveloperToolsPage.qml
+++ b/rockwork/qml/pages/DeveloperToolsPage.qml
@@ -261,6 +261,17 @@ Page {
                     sendLogsDocker.hide()
                 }
             }
+            ComboBox {
+                width: parent.width
+                label: qsTr("Syslog Verbosity")
+                menu: ContextMenu {
+                    MenuItem { text: qsTr("Debug") }
+                    MenuItem { text: qsTr("Warning") }
+                    MenuItem { text: qsTr("Critical") }
+                }
+                currentIndex: pebble.logLevel
+                onValueChanged: pebble.logLevel = currentIndex
+            }
 
             Button {
                 text: qsTr("Send watch logs")

--- a/rockwork/qml/pages/MainMenuPage.qml
+++ b/rockwork/qml/pages/MainMenuPage.qml
@@ -89,7 +89,7 @@ Page {
                                 anchors.centerIn: parent
                                 color: "transparent"
                                 visible: false
-                                property bool isRound: modelModel.get(root.pebble.model - 1).shape === "round"
+                                property bool isRound: modelModel.get(root.pebble.model).shape === "round"
                                 Rectangle {
                                     color: "blue"
                                     anchors.centerIn: parent

--- a/rockwork/qml/pages/PebbleModels.qml
+++ b/rockwork/qml/pages/PebbleModels.qml
@@ -24,5 +24,13 @@ ListModel {
     ListElement { image: 'qrc:///artwork/spalding-20mm-silver.png'; shape: "round" }
     ListElement { image: 'qrc:///artwork/spalding-20mm-black.png'; shape: "round" }
     ListElement { image: 'qrc:///artwork/spalding-14mm-rose-gold.png'; shape: "round" }
+    ListElement { image: 'qrc:///artwork/tintin-green.png'; shape: "rectangle" }// silk lime
+    ListElement { image: 'qrc:///artwork/tintin-red.png'; shape: "rectangle" }  // silk flame
+    ListElement { image: 'qrc:///artwork/tintin-white.png'; shape: "rectangle" }// silk white
+    ListElement { image: 'qrc:///artwork/tintin-blue.png'; shape: "rectangle" } // silk aqua
+    ListElement { image: 'qrc:///artwork/tintin-black.png'; shape: "rectangle" }// silk se black
+    ListElement { image: 'qrc:///artwork/tintin-white.png'; shape: "rectangle" }// silk se white
+    ListElement { image: 'qrc:///artwork/bobby-black.png'; shape: "rectangle" } // robert black
+    ListElement { image: 'qrc:///artwork/bobby-silver.png'; shape: "rectangle" }// robert silver
+    ListElement { image: 'qrc:///artwork/bobby-gold.png'; shape: "rectangle" }  // robert gold
 }
-

--- a/rockwork/translations/rockpool.ts
+++ b/rockwork/translations/rockpool.ts
@@ -339,11 +339,31 @@
     </message>
     <message>
         <location filename="../qml/pages/DeveloperToolsPage.qml" line="266"/>
+        <source>Syslog Verbosity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="268"/>
+        <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="269"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="270"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="277"/>
         <source>Send watch logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="276"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="287"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>

--- a/rockwork/translations/rockpool_de.ts
+++ b/rockwork/translations/rockpool_de.ts
@@ -339,11 +339,31 @@
     </message>
     <message>
         <location filename="../qml/pages/DeveloperToolsPage.qml" line="266"/>
+        <source>Syslog Verbosity</source>
+        <translation>Systemprotokoll Ausführlichkeit</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="268"/>
+        <source>Debug</source>
+        <translation>Debug</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="269"/>
+        <source>Warning</source>
+        <translation>Warnung</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="270"/>
+        <source>Critical</source>
+        <translation>Kritisch</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="277"/>
         <source>Send watch logs</source>
         <translation>Sende Uhr Protokolle</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="276"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="287"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>

--- a/rockwork/translations/rockpool_fr.ts
+++ b/rockwork/translations/rockpool_fr.ts
@@ -339,11 +339,31 @@
     </message>
     <message>
         <location filename="../qml/pages/DeveloperToolsPage.qml" line="266"/>
+        <source>Syslog Verbosity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="268"/>
+        <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="269"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="270"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="277"/>
         <source>Send watch logs</source>
         <translation>Envoyer les journaux de la montre</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="276"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="287"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>

--- a/rockwork/translations/rockpool_nl.ts
+++ b/rockwork/translations/rockpool_nl.ts
@@ -339,11 +339,31 @@
     </message>
     <message>
         <location filename="../qml/pages/DeveloperToolsPage.qml" line="266"/>
+        <source>Syslog Verbosity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="268"/>
+        <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="269"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="270"/>
+        <source>Critical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="277"/>
         <source>Send watch logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="276"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="287"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>

--- a/rockwork/translations/rockpool_ru.ts
+++ b/rockwork/translations/rockpool_ru.ts
@@ -341,11 +341,31 @@
     </message>
     <message>
         <location filename="../qml/pages/DeveloperToolsPage.qml" line="266"/>
+        <source>Syslog Verbosity</source>
+        <translation>Уровень системного журнала</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="268"/>
+        <source>Debug</source>
+        <translation>Отладочный</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="269"/>
+        <source>Warning</source>
+        <translation>Предупредительный</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="270"/>
+        <source>Critical</source>
+        <translation>Критический</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="277"/>
         <source>Send watch logs</source>
         <translation>Послать журнал с часов</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="276"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="287"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>

--- a/rockwork/translations/rockpool_uk.ts
+++ b/rockwork/translations/rockpool_uk.ts
@@ -339,11 +339,31 @@
     </message>
     <message>
         <location filename="../qml/pages/DeveloperToolsPage.qml" line="266"/>
+        <source>Syslog Verbosity</source>
+        <translation>Балакучисть Сіcтемного Журналу</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="268"/>
+        <source>Debug</source>
+        <translation>Налагодження</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="269"/>
+        <source>Warning</source>
+        <translation>Попередження</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="270"/>
+        <source>Critical</source>
+        <translation>Критичні</translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="277"/>
         <source>Send watch logs</source>
         <translation>Відіслати журнал з годинника</translation>
     </message>
     <message>
-        <location filename="../qml/pages/DeveloperToolsPage.qml" line="276"/>
+        <location filename="../qml/pages/DeveloperToolsPage.qml" line="287"/>
         <source>Cancel</source>
         <translation>Відмінити</translation>
     </message>

--- a/rockworkd/dbusinterface.cpp
+++ b/rockworkd/dbusinterface.cpp
@@ -453,17 +453,7 @@ QString DBusPebble::PlatformString() const
 
 QString DBusPebble::HardwarePlatform() const
 {
-    switch (m_pebble->hardwarePlatform()) {
-    case HardwarePlatformAplite:
-        return "aplite";
-    case HardwarePlatformBasalt:
-        return "basalt";
-    case HardwarePlatformChalk:
-        return "chalk";
-    default:
-        ;
-    }
-    return "unknown";
+    return m_pebble->platformName();
 }
 
 QString DBusPebble::SoftwareVersion() const

--- a/rockworkd/libpebble/blobdb.cpp
+++ b/rockworkd/libpebble/blobdb.cpp
@@ -60,16 +60,20 @@ void BlobDB::sendCommand(BlobDBId database, Operation operation, const QByteArra
     sendNext();
 }
 
-static QString BlobDBErrMsg[9]={"Unknown",
-                         "Success",
-                         "General Failure",
-                         "Invalid Operation",
-                         "Invalid BlobId",
-                         "Invalid Data",
-                         "No Such UUID",
-                         "BlobDb is Full",
-                         "BlobDb is Stale"
-                        };
+static QString BlobDBErrMsg[12]={
+    "Unknown",
+    "Success",
+    "General Failure",
+    "Invalid Operation",
+    "Invalid BlobId",
+    "Invalid Data",
+    "No Such UUID",
+    "BlobDb is Full",
+    "BlobDb is Stale",
+    "Operation Not Supported",
+    "Database is locked",
+    "Try Later"
+    };
 
 void BlobDB::blobCommandReply(const QByteArray &data)
 {

--- a/rockworkd/libpebble/bundle.cpp
+++ b/rockworkd/libpebble/bundle.cpp
@@ -49,6 +49,15 @@ QString Bundle::file(Bundle::FileType type, HardwarePlatform hardwarePlatform) c
             possibleDirs.append("chalk");
         }
         break;
+    case HardwarePlatformDiorite:
+        if (QFileInfo::exists(path() + "/diorite/")) {
+            possibleDirs.append("diorite");
+        }
+        if (QFileInfo::exists(path() + "/aplite/")) {
+            possibleDirs.append("aplite");
+        }
+        possibleDirs.append("");
+        break;
     default:
         possibleDirs.append("");
         ;

--- a/rockworkd/libpebble/enums.h
+++ b/rockworkd/libpebble/enums.h
@@ -16,12 +16,18 @@ enum HardwareRevision {
     HardwareRevisionSPALDING_EVT = 9,
     HardwareRevisionBOBBY_SMILES = 10,
     HardwareRevisionSPALDING = 11,
+    HardwareRevisionSILK_EVT = 12,
+    HardwareRevisionROBERT_EVT = 13,
+    HardwareRevisionSILK = 14,
 
     HardwareRevisionTINTIN_BB = 0xFF,
     HardwareRevisionTINTIN_BB2 = 0xFE,
     HardwareRevisionSNOWY_BB = 0xFD,
     HardwareRevisionSNOWY_BB2 = 0xFC,
-    HardwareRevisionSPALDING_BB2 = 0xFB
+    HardwareRevisionSPALDING_BB2 = 0xFB,
+    HardwareRevisionSILK_BB = 0xFA,
+    HardwareRevisionROBERT_BB = 0xF9,
+    HardwareRevisionSILK_BB2 = 0xF8
 };
 
 enum OS {
@@ -37,7 +43,9 @@ enum HardwarePlatform {
     HardwarePlatformUnknown = 0,
     HardwarePlatformAplite,
     HardwarePlatformBasalt,
-    HardwarePlatformChalk
+    HardwarePlatformChalk,
+    HardwarePlatformDiorite,
+    HardwarePlatformEmery
 };
 
 enum Model {
@@ -62,7 +70,16 @@ enum Model {
     ModelSpalding14Black = 18,
     ModelSpalding20Silver = 19,
     ModelSpalding20Black = 20,
-    ModelSpalding14RoseGold = 21
+    ModelSpalding14RoseGold = 21,
+    ModelSilkHrLime = 22,
+    ModelSilkHrFlame = 23,
+    ModelSilkHrWhite = 24,
+    ModelSilkHrAqua = 25,
+    ModelSilkSeBlack = 26,
+    ModelSilkSeWhite = 27,
+    ModelRobertBlack = 28,
+    ModelRobertSilver = 29,
+    ModelRobertGold = 30
 };
 
 enum MusicControlButton {

--- a/rockworkd/libpebble/jskit/jskitpebble.cpp
+++ b/rockworkd/libpebble/jskit/jskitpebble.cpp
@@ -267,19 +267,7 @@ QJSValue JSKitPebble::getActiveWatchInfo() const
 {
     QJSValue watchInfo = m_mgr->m_engine->newObject();
 
-    switch (m_mgr->m_pebble->hardwarePlatform()) {
-    case HardwarePlatformBasalt:
-        watchInfo.setProperty("platform", "basalt");
-        break;
-
-    case HardwarePlatformChalk:
-        watchInfo.setProperty("platform", "chalk");
-        break;
-
-    default:
-        watchInfo.setProperty("platform", "aplite");
-        break;
-    }
+    watchInfo.setProperty("platform", m_mgr->m_pebble->platformName());
 
     switch (m_mgr->m_pebble->model()) {
     case ModelTintinWhite:
@@ -360,6 +348,42 @@ QJSValue JSKitPebble::getActiveWatchInfo() const
 
     case ModelSpalding14RoseGold:
         watchInfo.setProperty("model", "pebble_time_round_rose_gold_14mm");
+        break;
+
+    case ModelSilkHrAqua:
+        watchInfo.setProperty("model", "pebble_2_hr_aqua");
+        break;
+
+    case ModelSilkHrFlame:
+        watchInfo.setProperty("model", "pebble_2_hr_flame");
+        break;
+
+    case ModelSilkHrLime:
+        watchInfo.setProperty("model", "pebble_2_hr_lime");
+        break;
+
+    case ModelSilkHrWhite:
+        watchInfo.setProperty("model", "pebble_2_hr_white");
+        break;
+
+    case ModelSilkSeBlack:
+        watchInfo.setProperty("model", "pebble_2_se_black");
+        break;
+
+    case ModelSilkSeWhite:
+        watchInfo.setProperty("model", "pebble_2_se_white");
+        break;
+
+    case ModelRobertBlack:
+        watchInfo.setProperty("model", "pebble_time_2_black");
+        break;
+
+    case ModelRobertGold:
+        watchInfo.setProperty("model", "pebble_time_2_gold");
+        break;
+
+    case ModelRobertSilver:
+        watchInfo.setProperty("model", "pebble_time_2_silver");
         break;
 
     default:

--- a/rockworkd/libpebble/pebble.cpp
+++ b/rockworkd/libpebble/pebble.cpp
@@ -357,6 +357,9 @@ QString Pebble::platformString() const
     case HardwareRevisionSNOWY_BB:
     case HardwareRevisionSNOWY_BB2:
     case HardwareRevisionSPALDING_BB2:
+    case HardwareRevisionSILK_BB:
+    case HardwareRevisionSILK_BB2:
+    case HardwareRevisionROBERT_BB:
         break;
     case HardwareRevisionTINTIN_EV2_4:
         return "ev2_4";
@@ -370,6 +373,12 @@ QString Pebble::platformString() const
         return "snowy_s3";
     case HardwareRevisionSPALDING:
         return "spalding";
+    case HardwareRevisionSILK_EVT:
+        return "silk_evt";
+    case HardwareRevisionSILK:
+        return "silk";
+    case HardwareRevisionROBERT_EVT:
+        return "robert_evt";
     }
     return QString();
 }

--- a/rockworkd/libpebble/pebble.cpp
+++ b/rockworkd/libpebble/pebble.cpp
@@ -306,9 +306,6 @@ void Pebble::setHardwareRevision(HardwareRevision hardwareRevision)
 {
     m_hardwareRevision = hardwareRevision;
     switch (m_hardwareRevision) {
-    case HardwareRevisionUNKNOWN:
-        m_hardwarePlatform = HardwarePlatformUnknown;
-        break;
     case HardwareRevisionTINTIN_EV1:
     case HardwareRevisionTINTIN_EV2:
     case HardwareRevisionTINTIN_EV2_3:
@@ -331,6 +328,18 @@ void Pebble::setHardwareRevision(HardwareRevision hardwareRevision)
     case HardwareRevisionSPALDING_BB2:
         m_hardwarePlatform = HardwarePlatformChalk;
         break;
+    case HardwareRevisionSILK:
+    case HardwareRevisionSILK_BB:
+    case HardwareRevisionSILK_BB2:
+    case HardwareRevisionSILK_EVT:
+        m_hardwarePlatform = HardwarePlatformDiorite;
+        break;
+    case HardwareRevisionROBERT_EVT:
+    case HardwareRevisionROBERT_BB:
+        m_hardwarePlatform = HardwarePlatformEmery;
+        break;
+    default:
+        m_hardwarePlatform = HardwarePlatformUnknown;
     }
 }
 
@@ -368,6 +377,24 @@ QString Pebble::platformString() const
 HardwarePlatform Pebble::hardwarePlatform() const
 {
     return m_hardwarePlatform;
+}
+
+QString Pebble::platformName() const
+{
+    switch(m_hardwarePlatform) {
+        case HardwarePlatformAplite:
+            return "aplite";
+        case HardwarePlatformBasalt:
+            return "basalt";
+        case HardwarePlatformChalk:
+            return "chalk";
+        case HardwarePlatformDiorite:
+            return "diorite";
+        case HardwarePlatformEmery:
+            return "emery";
+        default:
+            return "unknown";
+    }
 }
 
 QString Pebble::serialNumber() const

--- a/rockworkd/libpebble/pebble.cpp
+++ b/rockworkd/libpebble/pebble.cpp
@@ -535,7 +535,8 @@ bool Pebble::imperialUnits() const
 
 void Pebble::setWeatherUnits(const QString &u)
 {
-    m_weatherProv->setUnits(u.at(0));
+    if(m_weatherProv)
+        m_weatherProv->setUnits(u.at(0));
     QSettings appCfg(m_storagePath + "/appsettings.conf", QSettings::IniFormat);
     appCfg.beginGroup(WeatherApp::appConfigKey);
     appCfg.setValue("units",u);
@@ -543,7 +544,7 @@ void Pebble::setWeatherUnits(const QString &u)
 }
 QString Pebble::getWeatherUnits() const
 {
-    return m_weatherProv->getUnits();
+    return m_weatherProv ? m_weatherProv->getUnits() : 'm';
 }
 
 void Pebble::setWeatherApiKey(const QString &key)
@@ -619,7 +620,8 @@ void Pebble::initWeatherProvider(const QSettings &settings)
 
 void Pebble::setWeatherLanguage(const QString &lang)
 {
-    m_weatherProv->setLanguage(lang);
+    if(m_weatherProv)
+        m_weatherProv->setLanguage(lang);
     QSettings appCfg(m_storagePath + "/appsettings.conf", QSettings::IniFormat);
     appCfg.beginGroup(WeatherApp::appConfigKey);
     appCfg.setValue("language",lang);
@@ -627,7 +629,7 @@ void Pebble::setWeatherLanguage(const QString &lang)
 }
 QString Pebble::getWeatherLanguage() const
 {
-    return m_weatherProv->getLanguage();
+    return m_weatherProv ? m_weatherProv->getLanguage() : "";
 }
 
 QVariantList Pebble::getWeatherLocations() const
@@ -644,6 +646,7 @@ QVariantList Pebble::getWeatherLocations() const
         locs.append(city);
     }
     appCfg.endArray();
+    qDebug() << "Deserialized" << locs.size() << "locations";
     return locs;
 }
 

--- a/rockworkd/libpebble/pebble.h
+++ b/rockworkd/libpebble/pebble.h
@@ -74,6 +74,7 @@ public:
     Model model() const;
     HardwarePlatform hardwarePlatform() const;
     QString platformString() const;
+    QString platformName() const;
     QString serialNumber() const;
     QString language() const;
     quint16 langVer() const;


### PR DESCRIPTION
This PR adds 
* ability to set log severity  - the one to stdout which is now Warn by default
* support for new platforms - well, just definitions to be precise, support depends on BLE
and some small fixes
* fixes #53 - GUI glitch for PTR - round flag was shifted down by one so PTR Silver 14mm was wrongly marked as rectangle
* fixes #54 - new weather GUI causes service to segfault while attempting to read properties from non-initialized weather provider.