### PR TITLE
harbour-whisperfish notifications get sms icon

### DIFF
--- a/rockworkd/platformintegration/sailfish/sailfishplatform.cpp
+++ b/rockworkd/platformintegration/sailfish/sailfishplatform.cpp
@@ -166,6 +166,9 @@ AppID getAppID(watchfish::Notification *notification)
     } else if (notification->originPackage() == "org.telegram.messenger" || notification->category().startsWith("harbour.sailorgram")) {
         ret.type="telegram";
         ret.srcId=owner;
+    } else if (notification->category().startsWith("harbour-whisperfish")) {
+        ret.type="sms";
+        ret.srcId=owner;
     } else if (notification->originPackage() == "com.whatsapp" || notification->owner().toLower().contains("whatsup")) {
         ret.type="whatsapp";
         ret.srcId=owner;


### PR DESCRIPTION
I'm envious of Sailtrix, but they set `x-nemo.messaging.im` as notification category, which I suppose is technically reserved for the messaging application plugins. Feel free to suggest a different approach for getting the SMS-style icon for Whisperfish on my watch :-)