### PR TITLE
Fixes for settings pages

### DIFF
--- a/rockwork/jsm/PebbleProtoHandle.js
+++ b/rockwork/jsm/PebbleProtoHandle.js
@@ -41,7 +41,7 @@ PebbleProtoHandler.prototype = {
     dump("URI: "+aURI.spec+"\n");
     let hIdx = aURI.spec.indexOf("://")+3;
     let qIdx = aURI.spec.indexOf("#");
-    let action = aURI.spec.substring(hIdx,qIdx-1);
+    let action = aURI.spec.substring(hIdx,qIdx);
     let query = aURI.spec.substring(qIdx+1);
 
     let win = Services.embedlite.getAnyEmbedWindow(true);

--- a/rockwork/jsm/PebbleProtoHandle.js
+++ b/rockwork/jsm/PebbleProtoHandle.js
@@ -21,7 +21,7 @@ function PebbleProtoHandler() {
 }
 
 PebbleProtoHandler.prototype = {
-  QueryInterface: XPCOMUtils.generateQI([Ci.nsIProtocolHandler]),
+  QueryInterface: ChromeUtils.generateQI([Ci.nsIProtocolHandler]),
   classID: Components.ID("{0bb628c0-8f22-4273-b966-bae528f3a1d6}"),
   scheme: "pebble",
   protocolFlags: Ci.nsIProtocolHandler.URI_NORELATIVE |
@@ -54,7 +54,9 @@ PebbleProtoHandler.prototype = {
         "uri": aURI.spec
       }));
       //dump("Pebble sent the query "+query+"\n");
-      return Services.io.newChannel("file:///dev/null",null,null);
+      // The result cannot be handled by the WebView, so stop the process with a meaningful error.
+      // It would be better to render an empty page, but I did not manage to make achieve this.
+      throw new Error('message sent to pebble');
     }
     throw Components.results.NS_ERROR_ILLEGAL_VALUE;
   }

--- a/rockwork/pebble.cpp
+++ b/rockwork/pebble.cpp
@@ -459,7 +459,7 @@ void Pebble::setTimelineWindow()
 
 void Pebble::configurationClosed(const QString &uuid, const QString &url)
 {
-    m_iface->call("ConfigurationClosed", uuid, url.mid(17));
+    m_iface->call("ConfigurationClosed", uuid, url);
 }
 
 void Pebble::launchApp(const QString &uuid)

--- a/rockwork/qml/pages/AppSettingsPage.qml
+++ b/rockwork/qml/pages/AppSettingsPage.qml
@@ -15,7 +15,8 @@ Page {
         id: header
         width: parent.width
         anchors.top: parent.top
-        text: url
+        // The generated data URL from pebble-clay does not help the user and make it seem like a bug.
+        text: url.substring(0, 5) == "data:" ? "" : url
         height: Theme.itemSizeMedium
         horizontalAlignment: Text.AlignHCenter
         font.pixelSize: Theme.fontSizeTiny


### PR DESCRIPTION
Hi,

I was trying to make the settings of [my watchface](https://github.com/dscheinah/pkmn-watchface) work with rockpool. It is using `pebble-clay` which generates really long data: URLs. There were some problems (only ES5, `Function.toString` returning literal `[code]`, problems evaluation `this.$element`)  I could fix within my app. 

But there were some bugs I needed to fix in rockpool with this PR. Some were probably introduced with one of the latest browser engine updates:

- The action was cut off on the last char (`clos` instead of `close`)
- Data sent to JSKit is cut off/ empty
- `XPCOMUtils.generateQI` no longer exists
- `Services.io.newChannel` now expects more arguments but still throws errors if more arguments are given

Unfortunately I was not able to build the project due to a missing `quazip1-qt5` dependency. But I tested it with my watchface by modifying the files directly on the phone. (Tested the change in the `Pebble::configurationClosed` by sending a 16 char prefixed URL instead of the original one.)

Regards, Dscheinah