### PR TITLE
Fix Funtion.prototype.toString to not crash

### DIFF
--- a/rockworkd/libpebble/jskit/function.js
+++ b/rockworkd/libpebble/jskit/function.js
@@ -1,0 +1,3 @@
+Function.prototype.toString = function() {
+    return 'function() {}';
+}

--- a/rockworkd/libpebble/jskit/jsfiles.qrc
+++ b/rockworkd/libpebble/jskit/jsfiles.qrc
@@ -3,5 +3,6 @@
         <file>typedarray.js</file>
         <file>jskitsetup.js</file>
         <file>cacheLocalStorage.js</file>
+        <file>function.js</file>
     </qresource>
 </RCC>

--- a/rockworkd/libpebble/jskit/jskitmanager.cpp
+++ b/rockworkd/libpebble/jskit/jskitmanager.cpp
@@ -238,6 +238,7 @@ void JSKitManager::startJsApp()
 
     // Polyfills...
     loadJsFile(":/typedarray.js");
+    loadJsFile(":/function.js");
 
     // Now the actual script
     QString jsApp = m_curApp.file(AppInfo::FileTypeJsApp, HardwarePlatformUnknown);


### PR DESCRIPTION
To follow up on https://github.com/abranson/rockpool/pull/102 I decided to propose adding a shim for `Function.prototype.toString`. This does not really fix the problem but at least does not crash the whole page. With this, using `select` in `pebble-clay` will work but not show the current selected value. Also `slider` and `color` are affected in some way I currently cannot tell.

I don't expect any other code to make use of this feature and therefore assume this change to be safe. If another app uses the advanced features of `pebble-clay` like I did, it will not work if not handled manually... but at least the page does not crash instantly.

Sorry for the PR right after 1.15, but the solution just appeared to me with my latest watchface release.